### PR TITLE
Implement saslmemcached

### DIFF
--- a/limits/storage.py
+++ b/limits/storage.py
@@ -421,6 +421,7 @@ class SaslMemcachedStorage(MemcachedStorage):
                 "pylibmc"
             ).Client(self.cluster, username=self.username,
                      password=self.password, binary=True)
+            self.local_storage.storage.behaviors['cas'] = 1
         return self.local_storage.storage
 
     def incr(self, key, expiry, elastic_expiry=False):

--- a/limits/storage.py
+++ b/limits/storage.py
@@ -421,7 +421,6 @@ class SaslMemcachedStorage(MemcachedStorage):
                 "pylibmc"
             ).Client(self.cluster, username=self.username,
                      password=self.password, binary=True)
-            self.local_storage.storage.behaviors['cas'] = 1
         return self.local_storage.storage
 
     def incr(self, key, expiry, elastic_expiry=False):
@@ -433,6 +432,10 @@ class SaslMemcachedStorage(MemcachedStorage):
         :param bool elastic_expiry: whether to keep extending the rate limit
          window every hit.
         """
+
+        if elastic_expiry and not self.storage.behaviors.get('cas'):
+            self.storage.behaviors['cas'] = 1
+
         if not self.storage.add(key, 1, expiry):
             if elastic_expiry:
                 value, cas = self.storage.gets(key)

--- a/limits/storage.py
+++ b/limits/storage.py
@@ -80,6 +80,13 @@ class Storage(object):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def configure(self, options):
+        """
+        :param dict options: the options to set on the storage client
+        """
+        raise NotImplementedError
+
 
 
 
@@ -332,6 +339,18 @@ class MemcachedStorage(Storage):
         self.local_storage = threading.local()
         self.local_storage.storage = None
 
+    def configure(self, options):
+        """
+        :param dict options: pylibmc behaviors to set
+        :raise ConfigurationError: when pymemcache doesn't have the behavior
+        """
+
+        for key, value in options.items():
+            if not hasattr(self.storage, key):
+                raise ConfigurationError("pymemcache does not support the config key"
+                                         " %s. Please see http://goo.gl/SaNi8j" % key)
+            self.storage.behaviors[key] = value
+
     @property
     def storage(self):
         """
@@ -410,6 +429,18 @@ class SaslMemcachedStorage(MemcachedStorage):
                                      " please install pylibmc")  # pragma: no cover
         self.local_storage = threading.local()
         self.local_storage.storage = None
+
+    def configure(self, options):
+        """
+        :param dict options: pylibmc behaviors to set
+        :raise ConfigurationError: when pylibmc doesn't have the behavior
+        """
+
+        for key, value in options.items():
+            if key not in self.storage.behaviors:
+                raise ConfigurationError("pylibmc does not support the behavior"
+                                         " %s. Please see http://goo.gl/JVqjlM" % key)
+            self.storage.behaviors[key] = value
 
     @property
     def storage(self):

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,5 +4,6 @@ mock
 coverage
 nose-cov
 git+https://github.com/alisaifee/pymemcache.git#egg=pymemcache
+pylibmc
 redis
 hiro>0.1.6

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -12,7 +12,7 @@ from limits.errors import ConfigurationError
 from limits.limits import RateLimitItemPerMinute, RateLimitItemPerSecond
 from limits.storage import (
     MemoryStorage, RedisStorage, MemcachedStorage,
-    Storage, storage_from_string
+    SaslMemcachedStorage, Storage, storage_from_string
 )
 
 
@@ -24,6 +24,8 @@ class StorageTests(unittest.TestCase):
         self.assertTrue(isinstance(storage_from_string("memory://"), MemoryStorage))
         self.assertTrue(isinstance(storage_from_string("redis://localhost:6379"), RedisStorage))
         self.assertTrue(isinstance(storage_from_string("memcached://localhost:11211"), MemcachedStorage))
+        self.assertTrue(isinstance(storage_from_string("saslmemcached://username:password@localhost:11211"), SaslMemcachedStorage))
+        self.assertTrue(isinstance(storage_from_string("saslmemcached://username:password@localhost:11211,localhost:11211"), SaslMemcachedStorage))
         self.assertRaises(ConfigurationError, storage_from_string, "blah://")
 
     def test_in_memory(self):


### PR DESCRIPTION
This pull request implements saslmemcached via the following uri scheme:

```
saslmemcached://username:password@hostname.tld:port
saslmemcached://username:password@hostname.tld:port,hostname2.tld:port
```

Only one username/password combination can be used at a time
