### PR TITLE
Add support for connecting to redis over SSL

### DIFF
--- a/doc/source/storage.rst
+++ b/doc/source/storage.rst
@@ -44,6 +44,12 @@ Redis
  If the database is password protected the password can be provided in the url, for example
  :code:`redis://:foobared@localhost:6379`.
 
+Redis over SSL
+ Redis does not support SSL natively, but it is recommended to use stunnel to provide SSL suport.
+ The official Redis client :code:`redis-py` supports redis connections over SSL with the scheme
+ :code:`rediss`. :code:`rediss://localhost:6379/0` just like the normal redis connection, just
+ with the new scheme.
+
 Redis with Sentinel
  Requires the location(s) of the redis sentinal instances and the `service-name`
  that is monitored by the sentinels.

--- a/limits/storage.py
+++ b/limits/storage.py
@@ -398,6 +398,12 @@ class RedisStorage(RedisInteractor, Storage):
         """
         return super(RedisStorage, self).check(self.storage)
 
+class RedisSSLStorage(RedisStorage):
+    """
+    rate limit storage with redis as backend using SSL connection
+    """
+
+    STORAGE_SCHEME = "rediss"
 
 class RedisSentinelStorage(RedisInteractor, Storage):
     """


### PR DESCRIPTION
redis-py supports the URL scheme `rediss://` for connecting to redis
using an SSL connection. Even though redis itself does not natively
support SSL, it is a RedisLab's recommendation to use `stunnel` for SSL.

An integration test has been added using stunnel.