### PR TITLE
Improve ratelimit parsing

### DIFF
--- a/limits/util.py
+++ b/limits/util.py
@@ -6,9 +6,12 @@ import sys
 
 from .limits import GRANULARITIES
 
-
+SINGLE_EXPR = re.compile(
+    r"\s*([0-9]+)\s*(/|\s*per\s*)\s*([0-9]+)*\s*(hour|minute|second|day|month|year)s?\s*",
+    re.IGNORECASE
+)
 EXPR = re.compile(
-    r"\s*([0-9]+)\s*(/|\s*per\s*)\s*([0-9]+)*\s*(hour|minute|second|day|month|year)[s]*",
+    r"^{SINGLE}(:?;{SINGLE})*$".format(SINGLE=SINGLE_EXPR.pattern),
     re.IGNORECASE
 )
 
@@ -37,7 +40,8 @@ def parse_many(limit_string):
     if not EXPR.match(limit_string):
         raise ValueError("couldn't parse rate limit string '%s'" % limit_string)
     limits = []
-    for amount, _, multiples, granularity_string in  EXPR.findall(limit_string):
+    for limit in limit_string.split(';'):
+        amount, _, multiples, granularity_string = SINGLE_EXPR.match(limit).groups()
         granularity = granularity_from_string(granularity_string)
         limits.append(granularity(amount, multiples))
     return limits

--- a/tests/test_ratelimit_parser.py
+++ b/tests/test_ratelimit_parser.py
@@ -1,5 +1,5 @@
 import unittest
-from limits.util import parse, granularity_from_string
+from limits.util import parse, parse_many, granularity_from_string
 from limits import limits
 
 class RatelimitParserTests(unittest.TestCase):
@@ -40,7 +40,14 @@ class RatelimitParserTests(unittest.TestCase):
         self.assertEqual(parse("1 per 2 hours").get_expiry(), 2 * 60 * 60)
         self.assertEqual(parse("1/2 day").get_expiry(), 2 * 24 * 60 * 60)
 
+    def test_parse_many(self):
+        parsed = parse_many("1 per 3 hour; 1 per second")
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0].get_expiry(), 3 * 60 * 60)
+        self.assertEqual(parsed[1].get_expiry(), 1)
+
     def test_invalid_string(self):
         self.assertRaises(ValueError, parse, "1 per millienium")
         self.assertRaises(ValueError, granularity_from_string, "millenium")
+        self.assertRaises(ValueError, parse_many, "1 per year; 2 per decade")
 


### PR DESCRIPTION
Improves the accuracy of the rate limit string parsing. It would previously fail silently on some strings.
Before:
```
>>> from limits.util import parse_many
>>> parse_many('1 per hour; 10 perr day')
[1 per 1 hour]
>>> parse_many('1 per hour; 10 per day')
[1 per 1 hour, 10 per 1 day]
```
After:
```
>>> from limits.util import parse_many
>>> parse_many('1 per hour; 10 perr day')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/prillan/projects/git/limits/limits/util.py", line 41, in parse_many
    raise ValueError("couldn't parse rate limit string '%s'" % limit_string)
ValueError: couldn't parse rate limit string '1 per hour; 10 perr day'
>>> parse_many('1 per hour; 10 per day')
[1 per 1 hour, 10 per 1 day]
```

It would also parse `hoursssssssss` correctly before, that has been removed and now only allows `hour` and `hours`, as expected.

I've run the `tests.test_ratelimit_parser` tests and I even added some more. ~~If couldn't find any instructions as to how I would go about running the other tests so it would be much appreciated if someone else could do it.~~ Seems travis has got me covered!