### PR TITLE
Google App Engine Memcached storage class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ services:
 before_script:
     - make -f Makefile.tests redis-install
     - make -f Makefile.tests redis-start
+    - make -f Makefile.tests memcached-gae-install
 
 script: nosetests tests --with-cov -v
 after_success:

--- a/Makefile.tests
+++ b/Makefile.tests
@@ -73,4 +73,14 @@ redis-install:
 	gem install redis
 	sleep 3
 
+memcached-gae-install:
+	wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-147.0.0-linux-x86_64.tar.gz
+	tar -xvzf google-cloud-sdk-147.0.0-linux-x86_64.tar.gz
+	yes Y | google-cloud-sdk/bin/gcloud components install app-engine-python
+	ln -s google-cloud-sdk/platform/google_appengine/google google
+
+memcached-gae-clean:
+	rm google-cloud-sdk-147.0.0-linux-x86_64.tar.gz
+	rm -r google-cloud-sdk
+
 .PHONY: test

--- a/doc/source/storage.rst
+++ b/doc/source/storage.rst
@@ -37,6 +37,10 @@ Memcached
  :code:`memcached://localhost:11211` or
  :code:`memcached://localhost:11211,localhost:11212,192.168.1.1:11211` etc...
 
+Memcached on Google App Engine
+  Requires that you are working in the GAE SDK and have those API libraries available.
+  :code: `gaememcached://`
+
 Redis
  Requires the location of the redis server and optionally the database number.
  :code:`redis://localhost:6379` or :code:`redis://localhost:6379/1` (for database `1`).

--- a/limits/storage.py
+++ b/limits/storage.py
@@ -583,7 +583,9 @@ class MemcachedStorage(Storage):
         """
         parsed = urllib.parse.urlparse(uri)
         self.cluster = []
-        for loc in parsed.netloc.split(","):
+        for loc in parsed.netloc.strip().split(","):
+            if not loc:
+              continue
             host, port = loc.split(":")
             self.cluster.append((host, int(port)))
         self.library = options.get('library', 'pymemcache.client')
@@ -667,7 +669,7 @@ class MemcachedStorage(Storage):
         except:  # noqa
             return False
 
-class GAEMemcachedStorage(Storage):
+class GAEMemcachedStorage(MemcachedStorage):
     """
     rate limit storage with GAE memcache as backend
     """
@@ -675,44 +677,9 @@ class GAEMemcachedStorage(Storage):
     STORAGE_SCHEME = "gaememcached"
 
     def __init__(self, uri, **options):
-        """
-        :param str uri: memcached location of the form
-         'gae_memcache://hello'
-        :raise ConfigurationError: when pymemcached is not available
-        """
-        self.library = 'google.appengine.api.memcache'
-        self.client_getter = self.get_client
+      options["library"] = "google.appengine.api.memcache"
+      super(GAEMemcachedStorage, self).__init__(uri, **options)
 
-        if not get_dependency(self.library):
-            raise ConfigurationError("GAE memcache prerequisite not available."
-                                     " Make sure you are in the correct environment." % self.library)  # pragma: no cover
-        self.local_storage = threading.local()
-        self.local_storage.storage = None
-
-    def get_client(self, module):
-        """
-        returns a GAE memcache client.
-        :return:
-        """
-        return module.Client()
-
-    def call_memcached_func(self, func, *args, **kwargs):
-        return func(*args, **kwargs)
-
-    @property
-    def storage(self):
-        """
-        lazily creates a memcached client instance using a thread local
-        """
-        if not (hasattr(self.local_storage, "storage") and self.local_storage.storage):
-            self.local_storage.storage = self.client_getter(get_dependency(self.library))
-        return self.local_storage.storage
-
-    def get(self, key):
-        """
-        :param str key: the key to get the counter value for
-        """
-        return int(self.storage.get(key) or 0)
 
     def incr(self, key, expiry, elastic_expiry=False):
         """
@@ -740,12 +707,6 @@ class GAEMemcachedStorage(Storage):
                 return self.storage.incr(key, 1)
         self.call_memcached_func(self.storage.set, key + "/expires", expiry + time.time(), expiry)
         return 1
-
-    def get_expiry(self, key):
-        """
-        :param str key: the key to get the expiry for
-        """
-        return int(float(self.storage.get(key + "/expires") or time.time()))
 
     def check(self):
         """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,8 @@
 from functools import wraps
 import platform
 import unittest
+
+from google.appengine.ext import testbed
 from nose.plugins.skip import SkipTest
 import pymemcache.client
 import redis
@@ -33,3 +35,6 @@ class StorageTests(unittest.TestCase):
             "localhost-redis-sentinel"
         ).flushall()
         rediscluster.RedisCluster("localhost", 7000).flushall()
+        tb = testbed.Testbed()
+        tb.activate()
+        tb.init_memcache_stub()


### PR DESCRIPTION
I was manually subclassing this for a GAE app we use (we're plugging in `Flask-Limiter`, PR incoming) - because google has a specific memcache API you have to conform to, and figured it'd probably be useful for anyone else writing a Flask app on top of Google App Engine.

You'll see the changes in the new subclass are quite simple, and I kept the code similar to what's in the current Memcache storage plugin.

Tests added as well - please let me know what you think / any other changes you'd want to see to get this merged!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/limits/19)
<!-- Reviewable:end -->
