### PR TITLE
Add redis storage option for check during initialization

### DIFF
--- a/limits/storage.py
+++ b/limits/storage.py
@@ -367,9 +367,10 @@ class RedisStorage(RedisInteractor, Storage):
 
     STORAGE_SCHEME = "redis"
 
-    def __init__(self, uri, **_):
+    def __init__(self, uri, **options):
         """
         :param str uri: uri of the form 'redis://host:port or redis://host:port/db'
+        :param dict options: options
         :raise ConfigurationError: when the redis library is not available
          or if the redis host cannot be pinged.
         """
@@ -378,11 +379,11 @@ class RedisStorage(RedisInteractor, Storage):
                 "redis prerequisite not available"
             )  # pragma: no cover
         self.storage = get_dependency("redis").from_url(uri)
-        self.initialize_storage(uri)
+        self.initialize_storage(uri, **options)
         super(RedisStorage, self).__init__()
 
-    def initialize_storage(self, uri):
-        if not self.storage.ping():
+    def initialize_storage(self, uri, **options):
+        if options.get('check', True) and not self.check():
             raise ConfigurationError(
                 "unable to connect to redis at %s" % uri
             )  # pragma: no cover


### PR DESCRIPTION
Currently I it's not possible to run project with redis backend for limits while redis is unavailable. I suggest to make the check of redis connection optional. Or maybe this check should be deleted as there are not checks during memcached initialization?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/limits/22)
<!-- Reviewable:end -->
