### PR TITLE
make redis get_expiry compatible with redis-py 3.x.x

### DIFF
--- a/limits/storage.py
+++ b/limits/storage.py
@@ -373,7 +373,8 @@ class RedisInteractor(object):
         :param str key: the key to get the expiry for
         :param connection: Redis connection
         """
-        return int((connection.ttl(key) or 0) + time.time())
+        ttl = connection.ttl(key)
+        return int(max(connection.ttl(key), 0) + time.time())
 
     def check(self, connection):
         """


### PR DESCRIPTION
In redis-py 3.x.x, there is a breaking change with the return values of TTL where redis-py 2.x returned None:

> TTL and PTTL: The return value is now always an int and matches the official Redis command (>0 indicates the timeout, -1 indicates that the key exists but that it has no expire time set, -2 indicates that the key does not exist)

https://github.com/andymccurdy/redis-py#client-classes-redis-and-strictredis