### PR TITLE
remove extra ttl call

### DIFF
--- a/limits/storage.py
+++ b/limits/storage.py
@@ -375,7 +375,6 @@ class RedisInteractor(object):
         :param str key: the key to get the expiry for
         :param connection: Redis connection
         """
-        ttl = connection.ttl(key)
         return int(max(connection.ttl(key), 0) + time.time())
 
     def check(self, connection):


### PR DESCRIPTION
No need to call `connection.ttl()` twice, is there?