### PR TITLE
initialize master and replica storage in the constructor

### DIFF
--- a/limits/storage.py
+++ b/limits/storage.py
@@ -543,16 +543,10 @@ class RedisSentinelStorage(RedisStorage):
             password=password,
             **options
         )
+        self.storage = self.sentinel.master_for(self.service_name)
+        self.storage_slave = self.sentinel.slave_for(self.service_name)
         self.initialize_storage(uri)
         super(RedisStorage, self).__init__()
-
-    @property
-    def storage(self):
-        return self.sentinel.master_for(self.service_name)
-
-    @property
-    def storage_slave(self):
-        return self.sentinel.slave_for(self.service_name)
 
     def get(self, key):
         """


### PR DESCRIPTION
Setting up Redis master and replica storage with the property decorator
results in a new connection being opened for every call to the replica,
instead of reusing existing connections, which can quickly exhaust
available ports on a busy server. This moves the master and replica
initialization to the constructor of RedisSentinelStorage, allowing the
replica to correctly utilize the connection pooling features of redis-py