### PR TITLE
Adding reference in docs to the `Falcon-Limiter` module using `limits`

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -85,6 +85,7 @@ Projects using *limits*
 * `Flask-Limiter <http://flask-limiter.readthedocs.org>`_ : Rate limiting extension for Flask applications.
 * `djlimiter <http://djlimiter.readthedocs.org>`_: Rate limiting middleware for Django applications.
 * `sanic-limiter <https://github.com/bohea/sanic-limiter>`_: Rate limiting middleware for Sanic applications.
+* `Falcon-Limiter <https://falcon-limiter.readthedocs.org>`_ : Rate limiting extension for Falcon applications.
 
 References
 ----------


### PR DESCRIPTION
A new module using the `limits` module for the Falcon web framework.