### PR TITLE
Fix storage options support for memcache cluster libraries.

### DIFF
--- a/limits/storage/memcached.py
+++ b/limits/storage/memcached.py
@@ -39,7 +39,7 @@ class MemcachedStorage(Storage):
                 self.hosts = [parsed.path]
 
         self.library = options.pop('library', 'pymemcache.client')
-        self.cluster_library = options.pop('library', 'pymemcache.client.hash')
+        self.cluster_library = options.pop('cluster_library', 'pymemcache.client.hash')
         self.client_getter = options.pop('client_getter', self.get_client)
         self.options = options
 


### PR DESCRIPTION
I think this needs to have its own key, otherwise how do you specify it?