### PR TITLE
Avoid TypeError with fixed window strategies

### DIFF
--- a/limits/storage/memcached.py
+++ b/limits/storage/memcached.py
@@ -133,7 +133,7 @@ class MemcachedStorage(Storage):
                 )
                 return int(value or 0) + 1
             else:
-                return self.storage.incr(key, 1)
+                return self.storage.incr(key, 1) or 1
         self.call_memcached_func(
             self.storage.set,
             key + "/expires",


### PR DESCRIPTION
The MemcachedStorage.incr method should always return positive number.

Fixes: #68 