### PR TITLE
Improve test runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,6 @@ jobs:
         include:
           - python-version: 3.9
             os: ubuntu-latest
-          - python-version: 3.9
-            os: macos-latest
           - python-version: "3.10"
             marker: 'not asynchronous'
             os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,9 +34,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install -r requirements/ci.txt
-    - name: Start services
-      run: |
-        make setup-test-backends
     - name: Tests
       run: |
         py.test -m "${{ matrix.marker }}" --cov-report=xml --cov-branch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,17 +8,23 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         marker: [not integration]
+        os: [ubuntu-latest]
         include:
           - python-version: 3.9
+            os: ubuntu-latest
+          - python-version: 3.9
+            os: macos-latest
           - python-version: "3.10"
             marker: 'not asynchronous'
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+    - uses: docker-practice/actions-setup-docker@master
     - name: Cache dependencies
       uses: actions/cache@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,18 +8,16 @@ on:
 
 jobs:
   test:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8]
         marker: [not integration]
-        os: [ubuntu-latest]
         include:
           - python-version: 3.9
-            os: ubuntu-latest
+            marker: ''
           - python-version: "3.10"
             marker: 'not asynchronous'
-            os: ubuntu-latest
-    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - uses: docker-practice/actions-setup-docker@master

--- a/Makefile
+++ b/Makefile
@@ -1,49 +1,3 @@
-SHELL = bash
-HOST_OS = $(shell uname -s)
-ifeq ("$(HOST_OS)", "Darwin")
-HOST_IP = $(shell ipconfig getifaddr en0)
-OS_HACKS = osx-hacks
-else
-HOST_IP = $(shell hostname -I | awk '{print $$1}')
-endif
-
-PY_VERSION =$(shell python -c "import sys;print('.'.join(str(k) for k in sys.version_info[0:2]))")
-
-redis-uds-start:
-	redis-server --port 0 --unixsocket /tmp/limits.redis.sock --daemonize yes --pidfile /tmp/redis_unix-domain-socket.pid
-
-redis-uds-stop:
-	[ -e /tmp/redis_unix-domain-socket.pid ] && kill -9 `cat /tmp/redis_unix-domain-socket.pid` || true
-
-
-memcached-uds-start:
-	memcached -d -s /tmp/limits.memcached.sock -P /tmp/limits.memcached.uds.pid
-
-memcached-uds-stop:
-	[ -e /tmp/limits.memcached.uds.pid ] && kill `cat /tmp/limits.memcached.uds.pid` || true
-	rm -rf /tmp/limits.memcached.*.pid
-
-docker-down:
-	docker-compose down --remove-orphans
-
-docker-up: docker-down
-	HOST_OS=$(HOST_OS) HOST_IP=$(HOST_IP) docker-compose up -d
-	docker exec -i limits_redis-cluster-5_1 bash -c "echo yes | redis-cli --cluster create --cluster-replicas 1 $(HOST_IP):{7000..7005}"
-
-osx-hacks: redis-uds-stop memcached-uds-stop redis-uds-start memcached-uds-start
-
-setup-test-backends: $(OS_HACKS) docker-up
-teardown-test-backends: $(OS_HACKS) docker-down
-
-tests: setup-test-backends
-	pytest -m "not integration" --durations=10
-
-integration-tests: setup-test-backends
-	pytest -m integration
-
-all-tests: setup-test-backends
-	pytest -m --durations=10
-
 lint:
 	black --check
 	mypy limits
@@ -52,4 +6,5 @@ lint:
 lint-fix:
 	black tests limits
 	mypy limits
+	isort -r --profile=black tests limits
 	autoflake8 -i -r tests limits

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -58,20 +58,20 @@ To get started
    $ pip install -r requirements/dev.txt
 
 Since `limits` integrates with various backend storages, local development and running tests
-can require some setup.
+requires a a working `docker & docker-compose installation <https://docs.docker.com/compose/gettingstarted/>`_.
 
-You can use the provided Makefile to set up all the backends.
-This will require a working `docker & docker-compose installation <https://docs.docker.com/compose/gettingstarted/>`_.
-
-.. note:: On OSX you'll also need a working installation of `redis` & `memcached`
+Running the tests will start the relevant containers automatically - but will leave them running
+so as to not incur the overhead of starting up on each test run. To run the tests:
 
 .. code:: console
 
-   $ make setup-test-backends
-   $ # hack hack hack
    $ pytest
-   $ make teardown-test-backends
 
+Once you're done - you will probably want to clean up the docker containers::
+
+.. code:: console
+
+   $ docker-compose down
 
 
 Projects using *limits*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - 22123:22123
   memcached-uds:
     image: "memcached:${LIMITS_MEMCACHED_SERVER_VERSION:-latest}"
-    command: sh -c "test ${HOST_OS:-linux} = \"Darwin\" && exit || memcached -s /sockets/limits.memcached.sock -a 777"
+    command: sh -c "test ${HOST_OS} = \"Darwin\" && exit || memcached -s /sockets/limits.memcached.sock -a 777"
     volumes:
       - type: bind
         source: /tmp/
@@ -28,7 +28,7 @@ services:
   redis-sentinel-slave:
     image: "redis:${LIMITS_REDIS_SENTINEL_SERVER_VERSION:-latest}"
     depends_on: [redis-sentinel-master]
-    command: redis-server --port 6381 --slaveof 172.17.0.1 6380 --slave-announce-ip 172.17.0.1
+    command: redis-server --port 6381 --slaveof ${HOST_IP} 6380 --slave-announce-ip ${HOST_IP}
     ports:
       - '6381:6381'
   redis-sentinel:
@@ -36,17 +36,16 @@ services:
     depends_on: [redis-sentinel-slave]
     environment:
       - REDIS_MASTER_SET=localhost-redis-sentinel
-      - REDIS_MASTER_HOST=172.17.0.1
+      - REDIS_MASTER_HOST=${HOST_IP}
       - REDIS_MASTER_PORT_NUMBER=6380
     ports:
       - '26379:26379'
-
   redis-sentinel-auth:
     image: 'bitnami/redis-sentinel:${LIMITS_REDIS_SENTINEL_SERVER_VERSION:-latest}'
     depends_on: [redis-sentinel-slave]
     environment:
       - REDIS_MASTER_SET=localhost-redis-sentinel
-      - REDIS_MASTER_HOST=172.17.0.1
+      - REDIS_MASTER_HOST=${HOST_IP}
       - REDIS_MASTER_PORT_NUMBER=6380
       - REDIS_SENTINEL_PASSWORD=sekret
     ports:
@@ -54,43 +53,43 @@ services:
   # cluster
   redis-cluster-1:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: redis-server --port 7001 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip 172.17.0.1
+    command: redis-server --port 7001 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
     ports:
       - '7001:7001'
       - '17001:17001'
   redis-cluster-2:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: redis-server --port 7002 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip 172.17.0.1
+    command: redis-server --port 7002 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
     ports:
       - '7002:7002'
       - '17002:17002'
   redis-cluster-3:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: redis-server --port 7003 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip 172.17.0.1
+    command: redis-server --port 7003 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
     ports:
       - '7003:7003'
       - '17003:17003'
   redis-cluster-4:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: redis-server --port 7004 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip 172.17.0.1
+    command: redis-server --port 7004 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
     ports:
       - '7004:7004'
       - '17004:17004'
   redis-cluster-5:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: redis-server --port 7005 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip 172.17.0.1
+    command: redis-server --port 7005 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
     ports:
       - '7005:7005'
       - '17005:17005'
   redis-cluster-6:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: redis-server --port 7006 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip 172.17.0.1
+    command: redis-server --port 7006 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
     ports:
       - '7006:7006'
       - '17006:17006'
   redis-cluster-init:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: bash -c "echo yes | redis-cli --cluster create --cluster-replicas 1 172.17.0.1:7001 172.17.0.1:7002 172.17.0.1:7003 172.17.0.1:7004 172.17.0.1:7005 172.17.0.1:7006"
+    command: bash -c "echo yes | redis-cli --cluster create --cluster-replicas 1 ${HOST_IP}:7001 ${HOST_IP}:7002 ${HOST_IP}:7003 ${HOST_IP}:7004 ${HOST_IP}:7005 ${HOST_IP}:7006"
     depends_on: [redis-cluster-1, redis-cluster-2, redis-cluster-3, redis-cluster-4, redis-cluster-5, redis-cluster-6]
   redis-basic:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
@@ -111,7 +110,7 @@ services:
       - ./tests/tls:/tls
   redis-uds:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: sh -c "test ${HOST_OS:-linux} = \"Darwin\" && exit || redis-server --port 0 --unixsocket /sockets/limits.redis.sock --unixsocketperm 777"
+    command: sh -c "test ${HOST_OS} = \"Darwin\" && exit || redis-server --port 0 --unixsocket /sockets/limits.redis.sock --unixsocketperm 777"
     volumes:
       - type: bind
         source: /tmp/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - 22123:22123
   memcached-uds:
     image: "memcached:${LIMITS_MEMCACHED_SERVER_VERSION:-latest}"
-    command: sh -c "test ${HOST_OS} = \"Darwin\" && exit || memcached -s /sockets/limits.memcached.sock -a 777"
+    command: sh -c "test ${HOST_OS:-linux} = \"Darwin\" && exit || memcached -s /sockets/limits.memcached.sock -a 777"
     volumes:
       - type: bind
         source: /tmp/
@@ -28,7 +28,7 @@ services:
   redis-sentinel-slave:
     image: "redis:${LIMITS_REDIS_SENTINEL_SERVER_VERSION:-latest}"
     depends_on: [redis-sentinel-master]
-    command: redis-server --port 6381 --slaveof ${HOST_IP} 6380 --slave-announce-ip ${HOST_IP}
+    command: redis-server --port 6381 --slaveof 172.17.0.1 6380 --slave-announce-ip 172.17.0.1
     ports:
       - '6381:6381'
   redis-sentinel:
@@ -36,57 +36,62 @@ services:
     depends_on: [redis-sentinel-slave]
     environment:
       - REDIS_MASTER_SET=localhost-redis-sentinel
-      - REDIS_MASTER_HOST=${HOST_IP}
+      - REDIS_MASTER_HOST=172.17.0.1
       - REDIS_MASTER_PORT_NUMBER=6380
     ports:
       - '26379:26379'
+
   redis-sentinel-auth:
     image: 'bitnami/redis-sentinel:${LIMITS_REDIS_SENTINEL_SERVER_VERSION:-latest}'
     depends_on: [redis-sentinel-slave]
     environment:
       - REDIS_MASTER_SET=localhost-redis-sentinel
-      - REDIS_MASTER_HOST=${HOST_IP}
+      - REDIS_MASTER_HOST=172.17.0.1
       - REDIS_MASTER_PORT_NUMBER=6380
       - REDIS_SENTINEL_PASSWORD=sekret
     ports:
       - '36379:26379'
   # cluster
-  redis-cluster-0:
-    image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: redis-server --port 7000 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
-    ports:
-      - '7000:7000'
-      - '17000:17000'
   redis-cluster-1:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: redis-server --port 7001 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
+    command: redis-server --port 7001 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip 172.17.0.1
     ports:
       - '7001:7001'
       - '17001:17001'
   redis-cluster-2:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: redis-server --port 7002 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
+    command: redis-server --port 7002 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip 172.17.0.1
     ports:
       - '7002:7002'
       - '17002:17002'
   redis-cluster-3:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: redis-server --port 7003 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
+    command: redis-server --port 7003 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip 172.17.0.1
     ports:
       - '7003:7003'
       - '17003:17003'
   redis-cluster-4:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: redis-server --port 7004 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
+    command: redis-server --port 7004 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip 172.17.0.1
     ports:
       - '7004:7004'
       - '17004:17004'
   redis-cluster-5:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: redis-server --port 7005 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
+    command: redis-server --port 7005 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip 172.17.0.1
     ports:
       - '7005:7005'
       - '17005:17005'
+  redis-cluster-6:
+    image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
+    command: redis-server --port 7006 --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip 172.17.0.1
+    ports:
+      - '7006:7006'
+      - '17006:17006'
+  redis-cluster-init:
+    image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
+    command: bash -c "echo yes | redis-cli --cluster create --cluster-replicas 1 172.17.0.1:7001 172.17.0.1:7002 172.17.0.1:7003 172.17.0.1:7004 172.17.0.1:7005 172.17.0.1:7006"
+    depends_on: [redis-cluster-1, redis-cluster-2, redis-cluster-3, redis-cluster-4, redis-cluster-5, redis-cluster-6]
   redis-basic:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
     command: redis-server --port 7379
@@ -106,7 +111,7 @@ services:
       - ./tests/tls:/tls
   redis-uds:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
-    command: sh -c "test ${HOST_OS} = \"Darwin\" && exit || redis-server --port 0 --unixsocket /sockets/limits.redis.sock --unixsocketperm 777"
+    command: sh -c "test ${HOST_OS:-linux} = \"Darwin\" && exit || redis-server --port 0 --unixsocket /sockets/limits.redis.sock --unixsocketperm 777"
     volumes:
       - type: bind
         source: /tmp/

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,4 @@ addopts =
     -rfEsxX
     --cov=limits
     -m "not integration"
+    -K

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,9 +10,11 @@
 # Test related packages
 coverage
 flaky
+lovely-pytest-docker
 pytest
 pytest-asyncio
 pytest-cov
+pytest-lazy-fixture
 pytest-mock
 PyYAML
 hiro>0.1.6

--- a/tests/aio/storage/test_memcached.py
+++ b/tests/aio/storage/test_memcached.py
@@ -1,7 +1,6 @@
 import asyncio
 import time
 
-import pymemcache
 import pytest
 
 from limits import RateLimitItemPerMinute, RateLimitItemPerSecond
@@ -17,9 +16,8 @@ from tests import fixed_start
 @pytest.mark.flaky
 @pytest.mark.asynchronous
 class TestAsyncMemcachedStorage:
-    def setup_method(self):
-        pymemcache.client.Client(("localhost", 22122)).flush_all()
-        pymemcache.client.Client(("localhost", 22123)).flush_all()
+    @pytest.fixture(autouse=True)
+    def setup(self, memcached, memcached_cluster):
         self.storage_url = "async+memcached://localhost:22122"
 
     @pytest.mark.asyncio

--- a/tests/aio/storage/test_mongodb.py
+++ b/tests/aio/storage/test_mongodb.py
@@ -2,7 +2,6 @@ import asyncio
 import datetime
 import time
 
-import pymongo
 import pytest
 
 from limits import RateLimitItemPerMinute, RateLimitItemPerSecond
@@ -13,11 +12,10 @@ from limits.storage import storage_from_string
 
 @pytest.mark.asynchronous
 class TestAsyncMongoDBStorage:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, mongodb):
         self.storage_url = "mongodb://localhost:37017"
         self.storage = MongoDBStorage(f"async+{self.storage_url}")
-        pymongo.MongoClient(self.storage_url).limits.windows.drop()
-        pymongo.MongoClient(self.storage_url).limits.counters.drop()
 
     @pytest.mark.asyncio
     async def test_init_options(self, mocker):

--- a/tests/aio/test_strategy.py
+++ b/tests/aio/test_strategy.py
@@ -87,7 +87,7 @@ class TestAsyncWindow:
         assert (await limiter.get_window_stats(limit))[1] == 0
 
     @pytest.mark.asyncio
-    async def test_fixed_window_with_elastic_expiry_redis(self):
+    async def test_fixed_window_with_elastic_expiry_redis(self, redis_basic):
         storage = RedisStorage("async+redis://localhost:7379")
         limiter = FixedWindowElasticExpiryRateLimiter(storage)
         limit = RateLimitItemPerSecond(10, 2)
@@ -101,7 +101,9 @@ class TestAsyncWindow:
         assert (await limiter.get_window_stats(limit))[1] == 0
 
     @pytest.mark.asyncio
-    async def test_fixed_window_with_elastic_expiry_redis_sentinel(self):
+    async def test_fixed_window_with_elastic_expiry_redis_sentinel(
+        self, redis_sentinel
+    ):
         storage = RedisSentinelStorage(
             "async+redis+sentinel://localhost:26379/localhost-redis-sentinel"
         )
@@ -137,7 +139,7 @@ class TestAsyncWindow:
             assert (await limiter.get_window_stats(limit))[1] == 10
 
     @pytest.mark.asyncio
-    async def test_moving_window_mongo(self):
+    async def test_moving_window_mongo(self, mongodb):
         storage = MongoDBStorage("async+mongodb://localhost:37017")
         limiter = MovingWindowRateLimiter(storage)
         with hiro.Timeline().freeze() as timeline:
@@ -157,7 +159,7 @@ class TestAsyncWindow:
             assert (await limiter.get_window_stats(limit))[1] == 10
 
     @pytest.mark.asyncio
-    async def test_moving_window_redis(self):
+    async def test_moving_window_redis(self, redis_basic):
         storage = RedisStorage("async+redis://localhost:7379")
         limiter = MovingWindowRateLimiter(storage)
         limit = RateLimitItemPerSecond(10, 2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,241 @@
+import platform
+
+import pymemcache
+import pymemcache.client
+import pymongo
+import pytest
+import redis
+import redis.sentinel
+import rediscluster
+
+
+def check_redis_cluster_ready(*_):
+    try:
+        return (
+            rediscluster.RedisCluster("localhost", 7001).cluster_info()[
+                "172.17.0.1:7001"
+            ]["cluster_state"]
+            == "ok"
+        )
+    except:  # noqa
+        return False
+
+
+def check_sentinel_ready(host, port):
+    try:
+        return (
+            redis.sentinel.Sentinel([(host, port)])
+            .master_for("localhost-redis-sentinel")
+            .ping()
+        )
+    except:  # noqa
+        return False
+
+
+def check_sentinel_auth_ready(host, port):
+    try:
+        return (
+            redis.sentinel.Sentinel(
+                [(host, port)], sentinel_kwargs={"password": "sekret"}
+            )
+            .master_for("localhost-redis-sentinel")
+            .ping()
+        )
+    except:  # noqa
+        return False
+
+
+def check_mongo_ready(host, port):
+    try:
+        pymongo.MongoClient("mongodb://localhost:37017").server_info()
+        return True
+    except:  # noqa
+        return False
+
+
+@pytest.fixture(scope="session")
+def redis_basic_client(docker_services):
+    docker_services.start("redis-basic")
+
+    return redis.StrictRedis("localhost", 7379)
+
+
+@pytest.fixture(scope="session")
+def redis_uds_client(docker_services):
+    if platform.system().lower() == "darwin":
+        pytest.skip("Fixture not supported on OSX")
+    docker_services.start("redis-uds")
+
+    return redis.from_url("unix:///tmp/limits.redis.sock")
+
+
+@pytest.fixture(scope="session")
+def redis_auth_client(docker_services):
+    docker_services.start("redis-auth")
+
+    return redis.from_url("redis://:sekret@localhost:7389")
+
+
+@pytest.fixture(scope="session")
+def redis_ssl_client(docker_services):
+    docker_services.start("redis-ssl")
+    storage_url = (
+        "rediss://localhost:8379/0?ssl_cert_reqs=required"
+        "&ssl_keyfile=./tests/tls/client.key"
+        "&ssl_certfile=./tests/tls/client.crt"
+        "&ssl_ca_certs=./tests/tls/ca.crt"
+    )
+
+    return redis.from_url(storage_url)
+
+
+@pytest.fixture(scope="session")
+def redis_cluster_client(docker_services):
+    docker_services.start("redis-cluster-init")
+    docker_services.wait_for_service("redis-cluster-1", 7001, check_redis_cluster_ready)
+
+    return rediscluster.RedisCluster("localhost", 7001)
+
+
+@pytest.fixture(scope="session")
+def redis_sentinel_client(docker_services):
+    docker_services.start("redis-sentinel")
+    docker_services.wait_for_service("redis-sentinel", 26379, check_sentinel_ready)
+
+    return redis.sentinel.Sentinel([("localhost", 26379)])
+
+
+@pytest.fixture(scope="session")
+def redis_sentinel_auth_client(docker_services):
+    docker_services.start("redis-sentinel-auth")
+    docker_services.wait_for_service(
+        "redis-sentinel-auth", 26379, check_sentinel_auth_ready
+    )
+
+    return redis.sentinel.Sentinel(
+        [("localhost", 36379)], sentinel_kwargs={"password": "sekret"}
+    )
+
+
+@pytest.fixture(scope="session")
+def memcached_client(docker_services):
+    docker_services.start("memcached-1")
+
+    return pymemcache.Client(("localhost", 22122))
+
+
+@pytest.fixture(scope="session")
+def memcached_cluster_client(docker_services):
+    docker_services.start("memcached-1")
+    docker_services.start("memcached-2")
+
+    return pymemcache.client.HashClient([("localhost", 22122), ("localhost", 22123)])
+
+
+@pytest.fixture(scope="session")
+def memcached_uds_client(docker_services):
+    if platform.system().lower() == "darwin":
+        pytest.skip("Fixture not supported on OSX")
+    docker_services.start("memcached-uds")
+
+    return pymemcache.Client("/tmp/limits.memcached.sock")
+
+
+@pytest.fixture(scope="session")
+def mongodb_client(docker_services):
+    docker_services.start("mongodb")
+    docker_services.wait_for_service("mongodb", 27017, check_mongo_ready)
+
+    return pymongo.MongoClient("mongodb://localhost:37017")
+
+
+@pytest.fixture
+def memcached(memcached_client):
+    memcached_client.flush_all()
+
+    return memcached_client
+
+
+@pytest.fixture
+def memcached_uds(memcached_uds_client):
+    memcached_uds_client.flush_all()
+
+    return memcached_uds_client
+
+
+@pytest.fixture
+def memcached_cluster(memcached_cluster_client):
+    memcached_cluster_client.flush_all()
+
+    return memcached_cluster_client
+
+
+@pytest.fixture
+def redis_basic(redis_basic_client):
+    redis_basic_client.flushall()
+
+    return redis_basic
+
+
+@pytest.fixture
+def redis_ssl(redis_ssl_client):
+    redis_ssl_client.flushall()
+
+    return redis_ssl_client
+
+
+@pytest.fixture
+def redis_auth(redis_auth_client):
+    redis_auth.flushall()
+
+    return redis_auth
+
+
+@pytest.fixture
+def redis_uds(redis_uds_client):
+    redis_uds_client.flushall()
+
+    return redis_uds
+
+
+@pytest.fixture
+def redis_cluster(redis_cluster_client):
+    redis_cluster_client.flushall()
+
+    return redis_cluster
+
+
+@pytest.fixture
+def redis_sentinel(redis_sentinel_client):
+    redis_sentinel_client.master_for("localhost-redis-sentinel").flushall()
+
+    return redis_sentinel
+
+
+@pytest.fixture
+def redis_sentinel_auth(redis_sentinel_auth_client):
+    redis_sentinel_auth_client.master_for("localhost-redis-sentinel").flushall()
+
+    return redis_sentinel_auth_client
+
+
+@pytest.fixture
+def mongodb(mongodb_client):
+    mongodb_client.limits.windows.drop()
+    mongodb_client.limits.counters.drop()
+
+    return mongodb_client
+
+
+@pytest.fixture(scope="session")
+def docker_services_project_name():
+    return "limits"
+
+
+@pytest.fixture(scope="session")
+def docker_compose_files(pytestconfig):
+    """Get the docker-compose.yml absolute path.
+    Override this fixture in your tests if you need a custom location.
+    """
+
+    return ["docker-compose.yml"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
+import os
 import platform
+import socket
 
 import pymemcache
 import pymemcache.client
@@ -11,12 +13,8 @@ import rediscluster
 
 def check_redis_cluster_ready(*_):
     try:
-        return (
-            rediscluster.RedisCluster("localhost", 7001).cluster_info()[
-                "172.17.0.1:7001"
-            ]["cluster_state"]
-            == "ok"
-        )
+        rediscluster.RedisCluster("localhost", 7001).cluster_info()
+        return True
     except:  # noqa
         return False
 
@@ -51,6 +49,24 @@ def check_mongo_ready(host, port):
         return True
     except:  # noqa
         return False
+
+
+@pytest.fixture(scope="session")
+def host_ip_env():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("10.255.255.255", 1))
+        ip = s.getsockname()[0]
+    except Exception:
+        ip = "127.0.0.1"
+    finally:
+        s.close()
+    os.environ["HOST_IP"] = str(ip)
+
+
+@pytest.fixture(scope="session")
+def docker_services(host_ip_env, docker_services):
+    return docker_services
 
 
 @pytest.fixture(scope="session")

--- a/tests/storage/test_memcached.py
+++ b/tests/storage/test_memcached.py
@@ -14,8 +14,8 @@ from tests import fixed_start
 
 @pytest.mark.flaky
 class TestMemcachedStorage:
-    def setup_method(self):
-        pymemcache.client.Client(("localhost", 22122)).flush_all()
+    @pytest.fixture(autouse=True)
+    def setup(self, memcached):
         self.storage_url = "memcached://localhost:22122"
 
     def test_init_options(self, mocker):
@@ -41,7 +41,7 @@ class TestMemcachedStorage:
         assert limiter.hit(per_min)
 
     @fixed_start
-    def test_fixed_window_cluster(self):
+    def test_fixed_window_cluster(self, memcached_cluster):
         storage = MemcachedStorage("memcached://localhost:22122,localhost:22123")
         limiter = FixedWindowRateLimiter(storage)
         per_min = RateLimitItemPerSecond(10)
@@ -73,7 +73,7 @@ class TestMemcachedStorage:
         assert limiter.test(per_sec)
 
     @fixed_start
-    def test_fixed_window_with_elastic_expiry_cluster(self):
+    def test_fixed_window_with_elastic_expiry_cluster(self, memcached_cluster):
         storage = MemcachedStorage("memcached://localhost:22122,localhost:22123")
         limiter = FixedWindowElasticExpiryRateLimiter(storage)
         per_sec = RateLimitItemPerSecond(2, 2)

--- a/tests/storage/test_mongodb.py
+++ b/tests/storage/test_mongodb.py
@@ -2,6 +2,7 @@ import datetime
 import time
 
 import pymongo
+import pytest
 
 from limits import RateLimitItemPerMinute, RateLimitItemPerSecond
 from limits.storage import MongoDBStorage, storage_from_string
@@ -9,11 +10,10 @@ from limits.strategies import FixedWindowRateLimiter, MovingWindowRateLimiter
 
 
 class TestMongoDBStorage:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, mongodb):
         self.storage_url = "mongodb://localhost:37017"
         self.storage = MongoDBStorage(self.storage_url)
-        pymongo.MongoClient(self.storage_url).limits.windows.drop()
-        pymongo.MongoClient(self.storage_url).limits.counters.drop()
 
     def test_init_options(self, mocker):
         constructor = mocker.spy(pymongo, "MongoClient")

--- a/tests/storage/test_redis.py
+++ b/tests/storage/test_redis.py
@@ -1,5 +1,6 @@
 import time
 
+import pytest
 import redis
 
 from limits import RateLimitItemPerMinute, RateLimitItemPerSecond
@@ -64,10 +65,10 @@ class SharedRedisTests(object):
 
 
 class TestRedisStorage(SharedRedisTests):
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, redis_basic):
         self.storage_url = "redis://localhost:7379"
         self.storage = RedisStorage(self.storage_url)
-        redis.from_url(self.storage_url).flushall()
 
     def test_init_options(self, mocker):
         from_url = mocker.spy(redis, "from_url")
@@ -76,10 +77,10 @@ class TestRedisStorage(SharedRedisTests):
 
 
 class TestRedisUnixSocketStorage(SharedRedisTests):
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, redis_uds):
         self.storage_url = "redis+unix:///tmp/limits.redis.sock"
         self.storage = RedisStorage(self.storage_url)
-        redis.from_url("unix:///tmp/limits.redis.sock").flushall()
 
     def test_init_options(self, mocker):
         from_url = mocker.spy(redis, "from_url")
@@ -88,7 +89,8 @@ class TestRedisUnixSocketStorage(SharedRedisTests):
 
 
 class TestRedisSSLStorage(SharedRedisTests):
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, redis_ssl):
         self.storage_url = (
             "rediss://localhost:8379/0?ssl_cert_reqs=required"
             "&ssl_keyfile=./tests/tls/client.key"
@@ -96,7 +98,6 @@ class TestRedisSSLStorage(SharedRedisTests):
             "&ssl_ca_certs=./tests/tls/ca.crt"
         )
         self.storage = RedisStorage(self.storage_url)
-        redis.from_url(self.storage_url).flushall()
 
     def test_init_options(self, mocker):
         from_url = mocker.spy(redis, "from_url")

--- a/tests/storage/test_redis_cluster.py
+++ b/tests/storage/test_redis_cluster.py
@@ -1,3 +1,4 @@
+import pytest
 import rediscluster
 
 from limits.storage import RedisClusterStorage, storage_from_string
@@ -5,10 +6,10 @@ from tests.storage.test_redis import SharedRedisTests
 
 
 class TestRedisClusterStorage(SharedRedisTests):
-    def setup_method(self):
-        rediscluster.RedisCluster("localhost", 7000).flushall()
-        self.storage_url = "redis+cluster://localhost:7000"
-        self.storage = RedisClusterStorage("redis+cluster://localhost:7000")
+    @pytest.fixture(autouse=True)
+    def setup(self, redis_cluster):
+        self.storage_url = "redis+cluster://localhost:7001"
+        self.storage = RedisClusterStorage("redis+cluster://localhost:7001")
 
     def test_init_options(self, mocker):
         constructor = mocker.spy(rediscluster, "RedisCluster")


### PR DESCRIPTION
# Description
Remove reliance on makefile to setup containers for tests and instead use the `lovely-pytest-docker` plugin to lazily create containers as needed via fixtures.