### PR TITLE
Allow passing in an explicit connection pool for redis

### DIFF
--- a/doc/source/storage.rst
+++ b/doc/source/storage.rst
@@ -152,6 +152,12 @@ or :code:`redis+unix:///path/to/socket?db=n` (for database `n`).
 If the database is password protected the password can be provided in the url, for example
 :code:`redis://:foobared@localhost:6379` or :code:`redis+unix//:foobered/path/to/socket` if using a UDS..
 
+For scenarios where a redis connection pool is already available and can be reused, it can be provided
+in :paramref:`~limits.storage.storage_from_string.options`, for example::
+
+    pool = redis.connections.BlockingConnectionPool.from_url("redis://.....")
+    storage_from_string("redis://", connection_pool=pool)
+    
 Depends on: :pypi:`redis`
 
 Redis over SSL

--- a/tests/aio/storage/test_redis.py
+++ b/tests/aio/storage/test_redis.py
@@ -97,6 +97,15 @@ class TestAsyncRedisStorage(AsyncSharedRedisTests):
             from_url.spy_return.connection_pool.connection_kwargs["stream_timeout"] == 1
         )
 
+    @pytest.mark.asyncio
+    async def test_custom_connection_pool(self):
+        import coredis
+
+        pool = coredis.BlockingConnectionPool.from_url(self.storage_url)
+        storage = storage_from_string("async+redis://", connection_pool=pool)
+
+        assert await storage.check()
+
 
 @pytest.mark.redis
 class TestAsyncRedisAuthStorage(AsyncSharedRedisTests):

--- a/tests/aio/storage/test_redis.py
+++ b/tests/aio/storage/test_redis.py
@@ -59,6 +59,7 @@ class AsyncSharedRedisTests:
         assert await limiter.hit(per_min)
 
     @pytest.mark.asyncio
+    @pytest.mark.flaky
     async def test_moving_window_expiry(self):
         limiter = MovingWindowRateLimiter(self.storage)
         limit = RateLimitItemPerSecond(2)

--- a/tests/storage/test_redis.py
+++ b/tests/storage/test_redis.py
@@ -84,6 +84,12 @@ class TestRedisStorage(SharedRedisTests):
         assert storage_from_string(self.storage_url, socket_timeout=1).check()
         assert from_url.call_args[1]["socket_timeout"] == 1
 
+    def test_custom_connection_pool(self):
+        pool = redis.connection.BlockingConnectionPool.from_url(self.storage_url)
+        storage = storage_from_string("redis://", connection_pool=pool)
+
+        assert storage.check()
+
 
 @pytest.mark.redis
 class TestRedisUnixSocketStorage(SharedRedisTests):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -86,7 +86,7 @@ all_storage = pytest.mark.parametrize(
             "redis+sentinel://localhost:26379",
             {"service_name": "localhost-redis-sentinel"},
             pytest.lazy_fixture("redis_sentinel"),
-            marks=pytest.mark.redis_sentinel,
+            marks=[pytest.mark.redis_sentinel, pytest.mark.flaky],
         ),
         pytest.param(
             "redis+sentinel://localhost:26379/localhost-redis-sentinel",


### PR DESCRIPTION
# Description
Adds the `connection_pool` optional argument for redis storage so that users can reuse / explicitly manage the connection pool 

Reference: #77 