### PR TITLE
Fix redis moving window cost bug with varying costs

### DIFF
--- a/limits/resources/redis/lua_scripts/acquire_moving_window.lua
+++ b/limits/resources/redis/lua_scripts/acquire_moving_window.lua
@@ -12,7 +12,7 @@ for i=1, amount do
     entries[i] = timestamp
 end
 redis.call('lpush', KEYS[1], unpack(entries))
-redis.call('ltrim', KEYS[1], 0, limit - amount)
+redis.call('ltrim', KEYS[1], 0, limit)
 redis.call('expire', KEYS[1], expiry)
 
 return true

--- a/tests/storage/test_redis.py
+++ b/tests/storage/test_redis.py
@@ -48,6 +48,14 @@ class SharedRedisTests(object):
         limiter.clear(per_min)
         assert limiter.hit(per_min)
 
+    def test_moving_window_varying_cost(self):
+        limiter = MovingWindowRateLimiter(self.storage)
+        five_per_min = RateLimitItemPerMinute(5)
+        limiter.hit(five_per_min, cost=5)
+        assert not limiter.hit(five_per_min, cost=2)
+        limiter.clear(five_per_min)
+        assert limiter.hit(five_per_min)
+
     def test_moving_window_expiry(self):
         limiter = MovingWindowRateLimiter(self.storage)
         limit = RateLimitItemPerSecond(2)


### PR DESCRIPTION
Bug: if you first acquire at a larger cost and then at a lower cost,
the limit is not hit even if it should have been.