### PR TITLE
Migrate redis cluster implementation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,14 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
         marker: [not integration]
         os: [ubuntu-latest]
+        legacy_cluster: [False]
         include:
           - python-version: "3.10"
             marker: ''
+            os: ubuntu-latest
+          - python-version: "3.10"
+            marker: ''
+            legacy_cluster: True
             os: ubuntu-latest
     runs-on: "${{ matrix.os }}"
     steps:
@@ -68,6 +73,11 @@ jobs:
         python -m pip install "pip<22"
         python -m pip install --upgrade setuptools wheel
         pip install -r requirements/ci.txt
+    - name: Setup redis-py-cluster
+      if: ${{ matrix.legacy_cluster }}
+      run: |
+        pip uninstall redis -y
+        pip install redis-py-cluster
     - name: Tests
       run: |
         py.test -m "${{ matrix.marker }}" --cov-report=xml --cov-branch --max-runs=3

--- a/doc/source/storage.rst
+++ b/doc/source/storage.rst
@@ -157,7 +157,7 @@ in :paramref:`~limits.storage.storage_from_string.options`, for example::
 
     pool = redis.connections.BlockingConnectionPool.from_url("redis://.....")
     storage_from_string("redis://", connection_pool=pool)
-    
+
 Depends on: :pypi:`redis`
 
 Redis over SSL
@@ -196,7 +196,7 @@ Requires the location(s) of the redis cluster startup nodes (One is enough).
 :code:`redis+cluster://localhost:7000`
 or :code:`redis+cluster://localhost:7000,localhost:7001`
 
-Depends on: :pypi:`redis-py-cluster`
+Depends on: :pypi:`redis`
 
 MongoDB
 -------

--- a/limits/storage/redis_cluster.py
+++ b/limits/storage/redis_cluster.py
@@ -1,5 +1,10 @@
 import urllib
+import warnings
+from typing import Any, List, Tuple
 
+from packaging.version import Version
+
+from ..errors import ConfigurationError
 from .redis import RedisStorage
 
 
@@ -7,7 +12,7 @@ class RedisClusterStorage(RedisStorage):
     """
     Rate limit storage with redis cluster as backend
 
-    Depends on :pypi:`redis-cluster-py`
+    Depends on :pypi:`redis`
     """
 
     STORAGE_SCHEME = ["redis+cluster"]
@@ -16,30 +21,68 @@ class RedisClusterStorage(RedisStorage):
     DEFAULT_OPTIONS = {
         "max_connections": 1000,
     }
-    "Default options passed to the :class:`~rediscluster.RedisCluster`"
+    "Default options passed to the :class:`~redis.cluster.RedisCluster`"
 
-    DEPENDENCIES = ["rediscluster"]
+    DEPENDENCIES = ["redis", "rediscluster"]
+    FAIL_ON_MISSING_DEPENDENCY = False
 
     def __init__(self, uri: str, **options):
         """
         :param uri: url of the form
          ``redis+cluster://[:password]@host:port,host:port``
         :param options: all remaining keyword arguments are passed
-         directly to the constructor of :class:`rediscluster.RedisCluster`
-        :raise ConfigurationError: when the :pypi:`redis-cluster-py` library is not
-         available or if the redis host cannot be pinged.
+         directly to the constructor of :class:`redis.cluster.RedisCluster`
+        :raise ConfigurationError: when the :pypi:`redis` library is not
+         available or if the redis cluster cannot be reached.
         """
         parsed = urllib.parse.urlparse(uri)
         cluster_hosts = []
         for loc in parsed.netloc.split(","):
             host, port = loc.split(":")
-            cluster_hosts.append({"host": host, "port": int(port)})
+            cluster_hosts.append((host, int(port)))
 
-        self.storage = self.dependencies["rediscluster"].RedisCluster(
-            startup_nodes=cluster_hosts, **{**self.DEFAULT_OPTIONS, **options}
-        )
+        self.storage = None
+        self.using_redis_py = False
+        self.__pick_storage(cluster_hosts, **{**self.DEFAULT_OPTIONS, **options})
+        assert self.storage
         self.initialize_storage(uri)
         super(RedisStorage, self).__init__()
+
+    def __pick_storage(self, cluster_hosts: List[Tuple[str, int]], **options: Any):
+        redis_py = self.dependencies["redis"]
+        redis_cluster = self.dependencies["rediscluster"]
+        if redis_py:
+            redis_py_version = Version(redis_py.__version__)
+            if redis_py_version > Version("4.2.0"):
+                startup_nodes = [
+                    redis_py.cluster.ClusterNode(*c) for c in cluster_hosts
+                ]
+                self.storage = redis_py.cluster.RedisCluster(
+                    startup_nodes=startup_nodes, **options
+                )
+                self.using_redis_py = True
+                return
+        if redis_cluster:
+            warnings.warn(
+                (
+                    "Using redis-py-cluster is deprecated as the library has been"
+                    " absorbed by redis-py (>=4.2). This support will be removed"
+                    " in limits 2.5. To get rid of this warning, uninstall"
+                    " redis-py-cluster and ensure redis-py>=4.2.0 is installed"
+                )
+            )
+            self.storage = redis_cluster.RedisCluster(
+                startup_nodes=[{"host": c[0], "port": c[1]} for c in cluster_hosts],
+                **options
+            )
+        if not self.storage:
+            raise ConfigurationError(
+                (
+                    "Unable to find an implementation for redis cluster"
+                    " Cluster support requires either redis-py>=4.2 or"
+                    " redis-py-cluster"
+                )
+            )  # pragma: no cover
 
     def reset(self) -> int:
         """
@@ -53,5 +96,13 @@ class RedisClusterStorage(RedisStorage):
          On a large production based system, care should be taken with its
          usage as it could be slow on very large data sets"""
 
-        keys = self.storage.keys("LIMITER*")
-        return sum(self.storage.delete(k.decode("utf-8")) for k in keys)
+        if self.using_redis_py:
+            count = 0
+            for primary in self.storage.get_primaries():
+                node = self.storage.get_redis_connection(primary)
+                keys = node.keys("LIMITER*")
+                count += sum([node.delete(k.decode("utf-8")) for k in keys])
+            return count
+        else:
+            keys = self.storage.keys("LIMITER*")
+            return sum([self.storage.delete(k.decode("utf-8")) for k in keys])

--- a/limits/util.py
+++ b/limits/util.py
@@ -35,6 +35,7 @@ class LazyDependency:
     """
 
     DEPENDENCIES: List[str] = []
+    FAIL_ON_MISSING_DEPENDENCY: bool = True
     """
     The python modules this class has a dependency on.
     Used to lazily populate the :attr:`dependencies`
@@ -54,7 +55,7 @@ class LazyDependency:
             for name in self.DEPENDENCIES:
                 dependency = get_dependency(name)
 
-                if not dependency:
+                if not dependency and self.FAIL_ON_MISSING_DEPENDENCY:
                     raise ConfigurationError(
                         f"{name} prerequisite not available"
                     )  # pragma: no cover

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,1 +1,2 @@
 setuptools
+packaging>=21,<22

--- a/requirements/storage/rediscluster.txt
+++ b/requirements/storage/rediscluster.txt
@@ -1,1 +1,1 @@
-redis-py-cluster>=2.0.0,<3
+redis>=4.2.0

--- a/tests/storage/test_redis_cluster.py
+++ b/tests/storage/test_redis_cluster.py
@@ -1,5 +1,4 @@
 import pytest
-import rediscluster
 
 from limits.storage import RedisClusterStorage, storage_from_string
 from tests.storage.test_redis import SharedRedisTests
@@ -13,6 +12,10 @@ class TestRedisClusterStorage(SharedRedisTests):
         self.storage = RedisClusterStorage("redis+cluster://localhost:7001")
 
     def test_init_options(self, mocker):
+        try:
+            import rediscluster
+        except ImportError:
+            return pytest.skip()
         constructor = mocker.spy(rediscluster, "RedisCluster")
         assert storage_from_string(self.storage_url, socket_timeout=1).check()
         assert constructor.call_args[1]["socket_timeout"] == 1


### PR DESCRIPTION
# Description

Migrate redis cluster implementation to use redis instead of redis-py-cluster as the library is no longer maintained and has been migrated into the main redis py distribution.
