### PR TITLE
fix typo and missing colon for redis socket

### DIFF
--- a/doc/source/storage.rst
+++ b/doc/source/storage.rst
@@ -150,7 +150,7 @@ If the redis server is listening over a unix domain socket you can use :code:`re
 or :code:`redis+unix:///path/to/socket?db=n` (for database `n`).
 
 If the database is password protected the password can be provided in the url, for example
-:code:`redis://:foobared@localhost:6379` or :code:`redis+unix//:foobered/path/to/socket` if using a UDS..
+:code:`redis://:foobared@localhost:6379` or :code:`redis+unix://:foobered/path/to/socket` if using a UDS..
 
 For scenarios where a redis connection pool is already available and can be reused, it can be provided
 in :paramref:`~limits.storage.storage_from_string.options`, for example::

--- a/limits/storage/__init__.py
+++ b/limits/storage/__init__.py
@@ -43,7 +43,7 @@ def storage_from_string(
 
         memory = storage_from_string("async+memory://")
         memcached = storage_from_string("async+memcached://localhost:11211")
-        redis = storage_from_string("asycn+redis://localhost:6379")
+        redis = storage_from_string("async+redis://localhost:6379")
 
     :param storage_string: a string of the form ``scheme://host:port``.
      More details about supported storage schemes can be found at


### PR DESCRIPTION
* fix a typo: asycn -> async
* fix missing colon for redis unix socket url
