### PR TITLE
Do not fail on empty string in `LazyDependency#parse_many`

### DIFF
--- a/limits/util.py
+++ b/limits/util.py
@@ -139,8 +139,12 @@ def parse_many(limit_string: str) -> List[RateLimitItem]:
 
     """
 
+    if not limit_string:
+        return []
+
     if not (isinstance(limit_string, str) and EXPR.match(limit_string)):
         raise ValueError("couldn't parse rate limit string '%s'" % limit_string)
+
     limits = []
 
     for limit in SEPARATORS.split(limit_string):


### PR DESCRIPTION
Hi,

First of all, thanks for this package and a Happy New Year! :)

This PR aims to solve a following issue:
In order to achieve dynamic rate limits, I've found myself using this (simplified) idiom in my app, like so:

```py
def current_ratelimit():
    if user := current_user():
        if ratelimit := user.ratelimit:
            return ratelimit

def current_limiter():
    return limiter.limit(current_ratelimit)

# later on ...

class FooAPI(MethodView):
    decorators = [current_limiter()]
```

thing is, that in case the `user.ratelimit` is not defined, every request ends up logging:

```
failed to load ratelimit for function app.resources.foo.View.as_view.<locals>.view: couldn't parse rate limit string 'None'
```

... which I reckon is caused by materializing rate limit string and trying to parse an empty value.

This PR makes the method responsible silently bail-out on `None` and empty strings.

PS. I'm using this library via `flask-limiter`