### PR TITLE
Disallow acquiring > limit in moving window

### DIFF
--- a/limits/aio/storage/memory.py
+++ b/limits/aio/storage/memory.py
@@ -102,6 +102,9 @@ class MemoryStorage(Storage, MovingWindowSupport):
         :param expiry: expiry of the entry
         :param amount: the number of entries to acquire
         """
+        if amount > limit:
+            return False
+
         self.events.setdefault(key, [])
         await self.__schedule_expiry()
         timestamp = time.time()

--- a/limits/aio/storage/mongodb.py
+++ b/limits/aio/storage/mongodb.py
@@ -240,6 +240,9 @@ class MongoDBStorage(Storage, MovingWindowSupport):
         """
         await self.create_indices()
 
+        if amount > limit:
+            return False
+
         timestamp = time.time()
         try:
             updates: Dict[str, Any] = {  # type: ignore

--- a/limits/resources/redis/lua_scripts/acquire_moving_window.lua
+++ b/limits/resources/redis/lua_scripts/acquire_moving_window.lua
@@ -1,12 +1,18 @@
-local amount = tonumber(ARGV[4])
-local entry = redis.call('lindex', KEYS[1], tonumber(ARGV[2]) - amount)
 local timestamp = tonumber(ARGV[1])
+local limit = tonumber(ARGV[2])
 local expiry = tonumber(ARGV[3])
+local amount = tonumber(ARGV[4])
+
+if amount > limit then
+    return false
+end
+
+local entry = redis.call('lindex', KEYS[1], limit - amount)
+
 
 if entry and tonumber(entry) >= timestamp - expiry then
     return false
 end
-local limit = tonumber(ARGV[2])
 local entries= {}
 for i=1, amount do
     entries[i] = timestamp

--- a/limits/storage/memory.py
+++ b/limits/storage/memory.py
@@ -96,6 +96,9 @@ class MemoryStorage(Storage, MovingWindowSupport):
         :param expiry: expiry of the entry
         :param amount: the number of entries to acquire
         """
+        if amount > limit:
+            return False
+
         self.events.setdefault(key, [])
         self.__schedule_expiry()
         timestamp = time.time()

--- a/limits/storage/mongodb.py
+++ b/limits/storage/mongodb.py
@@ -205,6 +205,9 @@ class MongoDBStorage(Storage, MovingWindowSupport):
         :param expiry: expiry of the entry
         :param amount: the number of entries to acquire
         """
+        if amount > limit:
+            return False
+
         timestamp = time.time()
         try:
             updates: Dict[str, Any] = {  # type: ignore

--- a/tests/aio/test_storage.py
+++ b/tests/aio/test_storage.py
@@ -200,6 +200,29 @@ class TestConcreteStorages:
         time.sleep(1.1)
         assert await storage.get(limit.key_for()) == 0
 
+    async def test_incr_custom_amount(self, uri, args, expected_instance, fixture):
+        storage = storage_from_string(uri, **args)
+        limit = RateLimitItemPerMinute(1)
+        assert 1 == await storage.incr(limit.key_for(), limit.get_expiry(), amount=1)
+        assert 11 == await storage.incr(limit.key_for(), limit.get_expiry(), amount=10)
+
+    async def test_acquire_entry_custom_amount(
+        self, uri, args, expected_instance, fixture
+    ):
+        if not issubclass(expected_instance, MovingWindowSupport):
+            pytest.skip("%s does not support acquire entry" % expected_instance)
+        storage = storage_from_string(uri, **args)
+        limit = RateLimitItemPerMinute(10)
+        assert not await storage.acquire_entry(
+            limit.key_for(), limit.amount, limit.get_expiry(), amount=11
+        )
+        assert await storage.acquire_entry(
+            limit.key_for(), limit.amount, limit.get_expiry(), amount=1
+        )
+        assert not await storage.acquire_entry(
+            limit.key_for(), limit.amount, limit.get_expiry(), amount=10
+        )
+
     async def test_storage_check(self, uri, args, expected_instance, fixture):
         assert await (storage_from_string(uri, **args)).check()
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -212,6 +212,27 @@ class TestConcreteStorages:
         time.sleep(1.1)
         assert storage.get(limit.key_for()) == 0
 
+    def test_incr_custom_amount(self, uri, args, expected_instance, fixture):
+        storage = storage_from_string(uri, **args)
+        limit = RateLimitItemPerMinute(1)
+        assert 1 == storage.incr(limit.key_for(), limit.get_expiry(), amount=1)
+        assert 11 == storage.incr(limit.key_for(), limit.get_expiry(), amount=10)
+
+    def test_acquire_entry_custom_amount(self, uri, args, expected_instance, fixture):
+        if not issubclass(expected_instance, MovingWindowSupport):
+            pytest.skip("%s does not support acquire entry" % expected_instance)
+        storage = storage_from_string(uri, **args)
+        limit = RateLimitItemPerMinute(10)
+        assert not storage.acquire_entry(
+            limit.key_for(), limit.amount, limit.get_expiry(), amount=11
+        )
+        assert storage.acquire_entry(
+            limit.key_for(), limit.amount, limit.get_expiry(), amount=1
+        )
+        assert not storage.acquire_entry(
+            limit.key_for(), limit.amount, limit.get_expiry(), amount=10
+        )
+
     def test_storage_check(self, uri, args, expected_instance, fixture):
         assert storage_from_string(uri, **args).check()
 


### PR DESCRIPTION
# Description

Attempting to hit a moving window rate limiter with a `cost` greater than the maximum was resulting in an incorrect response of `True` as an out of bounds access to the moving window presented as an empty window. 

## Related Issues
- #151 