### PR TITLE
Support authentication through storage string for redis cluster

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,28 @@ services:
     depends_on: [redis-ssl-cluster-1, redis-ssl-cluster-2, redis-ssl-cluster-3, redis-ssl-cluster-4, redis-ssl-cluster-5, redis-ssl-cluster-6]
     volumes:
       - ./tests/tls:/tls
+  redis-cluster-auth-1:
+    image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
+    command: redis-server --port 8400 ${DEFAULT_ARGS---enable-debug-command yes} --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP} --requirepass sekret
+    ports:
+      - '8400:8400'
+      - '18400:18400'
+  redis-cluster-auth-2:
+    image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
+    command: redis-server --port 8401 ${DEFAULT_ARGS---enable-debug-command yes} --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP} --requirepass sekret
+    ports:
+      - '8401:8401'
+      - '18401:18401'
+  redis-cluster-auth-3:
+    image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
+    command: redis-server --port 8402 ${DEFAULT_ARGS---enable-debug-command yes} --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP} --requirepass sekret
+    ports:
+      - '8402:8402'
+      - '18402:18402'
+  redis-cluster-auth-init:
+    image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
+    command: bash -c "echo yes | redis-cli --cluster create --cluster-replicas 0 ${HOST_IP}:8400 ${HOST_IP}:8401 ${HOST_IP}:8402 -a sekret"
+    depends_on: [redis-cluster-auth-1, redis-cluster-auth-2, redis-cluster-auth-3]
   redis-basic:
     image: "redis:${LIMITS_REDIS_SERVER_VERSION:-latest}"
     command: redis-server --port 7379

--- a/tests/aio/test_storage.py
+++ b/tests/aio/test_storage.py
@@ -159,6 +159,14 @@ class TestBaseStorage:
             id="redis-cluster",
         ),
         pytest.param(
+            "async+redis+cluster://:sekret@localhost:8400/",
+            {},
+            RedisClusterStorage,
+            pytest.lazy_fixture("redis_auth_cluster"),
+            marks=pytest.mark.redis_cluster,
+            id="redis-cluster-auth",
+        ),
+        pytest.param(
             "async+mongodb://localhost:37017/",
             {},
             MongoDBStorage,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -173,6 +173,14 @@ class TestBaseStorage:
             id="redis-cluster",
         ),
         pytest.param(
+            "redis+cluster://:sekret@localhost:8400/",
+            {},
+            RedisClusterStorage,
+            pytest.lazy_fixture("redis_auth_cluster"),
+            marks=pytest.mark.redis_cluster,
+            id="redis-cluster-auth",
+        ),
+        pytest.param(
             "mongodb://localhost:37017/",
             {},
             MongoDBStorage,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -81,6 +81,13 @@ all_storage = pytest.mark.parametrize(
             id="redis-cluster",
         ),
         pytest.param(
+            "redis+cluster://:sekret@localhost:8400/",
+            {},
+            pytest.lazy_fixture("redis_auth_cluster"),
+            marks=pytest.mark.redis_cluster,
+            id="redis-cluster-auth",
+        ),
+        pytest.param(
             "redis+cluster://localhost:8301",
             {
                 "ssl": True,
@@ -134,6 +141,13 @@ moving_window_storage = pytest.mark.parametrize(
             pytest.lazy_fixture("redis_cluster"),
             marks=pytest.mark.redis_cluster,
             id="redis-cluster",
+        ),
+        pytest.param(
+            "redis+cluster://:sekret@localhost:8400/",
+            {},
+            pytest.lazy_fixture("redis_auth_cluster"),
+            marks=pytest.mark.redis_cluster,
+            id="redis-cluster-auth",
         ),
         pytest.param(
             "redis+cluster://localhost:8301",
@@ -198,6 +212,13 @@ async_all_storage = pytest.mark.parametrize(
             id="redis-cluster",
         ),
         pytest.param(
+            "async+redis+cluster://:sekret@localhost:8400/",
+            {},
+            pytest.lazy_fixture("redis_auth_cluster"),
+            marks=pytest.mark.redis_cluster,
+            id="redis-cluster-auth",
+        ),
+        pytest.param(
             "async+redis+cluster://localhost:8301",
             {
                 "ssl": True,
@@ -251,6 +272,13 @@ async_moving_window_storage = pytest.mark.parametrize(
             pytest.lazy_fixture("redis_cluster"),
             marks=pytest.mark.redis_cluster,
             id="redis-cluster",
+        ),
+        pytest.param(
+            "async+redis+cluster://:sekret@localhost:8400/",
+            {},
+            pytest.lazy_fixture("redis_auth_cluster"),
+            marks=pytest.mark.redis_cluster,
+            id="redis-cluster-auth",
         ),
         pytest.param(
             "async+redis+cluster://localhost:8301",


### PR DESCRIPTION
# Description
If username/password are provided in the storage string uri for redis cluster a parsing error occurs and infact there is no provision to extract the authentication details from the string.

## Related issues
- #153 