### PR TITLE
Add namespace prefix to Redis keys

### DIFF
--- a/tests/aio/test_storage.py
+++ b/tests/aio/test_storage.py
@@ -237,11 +237,13 @@ class TestConcreteStorages:
     async def test_storage_reset(self, uri, args, expected_instance, fixture):
         if expected_instance == MemcachedStorage:
             pytest.skip("Reset not supported for memcached")
-        limit = RateLimitItemPerMinute(10)
+        limit1 = RateLimitItemPerMinute(10)  # default namespace, LIMITER
+        limit2 = RateLimitItemPerMinute(10, namespace="OTHER")
         storage = storage_from_string(uri, **args)
         for i in range(10):
-            await storage.incr(limit.key_for(str(i)), limit.get_expiry())
-        assert await storage.reset() == 10
+            await storage.incr(limit1.key_for(str(i)), limit1.get_expiry())
+            await storage.incr(limit2.key_for(str(i)), limit2.get_expiry())
+        assert await storage.reset() == 20
 
     async def test_storage_clear(self, uri, args, expected_instance, fixture):
         limit = RateLimitItemPerMinute(10)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -247,11 +247,13 @@ class TestConcreteStorages:
     def test_storage_reset(self, uri, args, expected_instance, fixture):
         if expected_instance == MemcachedStorage:
             pytest.skip("Reset not supported for memcached")
-        limit = RateLimitItemPerMinute(10)
+        limit1 = RateLimitItemPerMinute(10)  # default namespace, LIMITER
+        limit2 = RateLimitItemPerMinute(10, namespace="OTHER")
         storage = storage_from_string(uri, **args)
         for i in range(10):
-            storage.incr(limit.key_for(str(i)), limit.get_expiry())
-        assert storage.reset() == 10
+            storage.incr(limit1.key_for(str(i)), limit1.get_expiry())
+            storage.incr(limit2.key_for(str(i)), limit2.get_expiry())
+        assert await storage.reset() == 20
 
     def test_storage_clear(self, uri, args, expected_instance, fixture):
         limit = RateLimitItemPerMinute(10)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -253,7 +253,7 @@ class TestConcreteStorages:
         for i in range(10):
             storage.incr(limit1.key_for(str(i)), limit1.get_expiry())
             storage.incr(limit2.key_for(str(i)), limit2.get_expiry())
-        assert await storage.reset() == 20
+        assert storage.reset() == 20
 
     def test_storage_clear(self, uri, args, expected_instance, fixture):
         limit = RateLimitItemPerMinute(10)


### PR DESCRIPTION
Picking up the feedback for https://github.com/alisaifee/limits/pull/173 and based on [the current solution for `etcd`](https://github.com/alisaifee/limits/blob/ada96bb4afc9729b4aac2552209a78428a27c313/limits/storage/etcd.py#L47-L48), I added a `PREFIX` to the Redis storages and used it to generate its keys, therefore allowing for a more targeted cleanup of values in `reset()`.

I opted for generating the keys right before they were used against the storage, but we may as well move the key generation right at the beginning of each of the entrypoints, i.e. all the public functions. Happy to hear your feedback.

Besides, I guess this might be considered a breaking change? Not sure if you'd like to do something specific about that or you are just happy to add that as a note in the release notes.