### PR TITLE
Fix usage of `importlib_resources` for Python >= 3.7

### DIFF
--- a/limits/util.py
+++ b/limits/util.py
@@ -8,7 +8,10 @@ from collections import UserDict
 from types import ModuleType
 from typing import TYPE_CHECKING, cast
 
-import importlib_resources
+try:
+    import importlib_resources
+except ModuleNotFoundError:
+    from importlib import resources as importlib_resources
 from packaging.version import Version
 
 from limits.typing import Dict, List, NamedTuple, Optional, Tuple, Type, Union

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,4 +1,4 @@
 deprecated>=1.2
-importlib_resources>=1.3
+importlib_resources>=1.3; python_version < '3.7'
 packaging>=21,<24
 typing_extensions


### PR DESCRIPTION
`importlib.resources` is part of the Python standard library
since Python 3.7:

https://docs.python.org/3/library/importlib.resources.html

Make sure limits is compatible with Python >= 3.7.
