### PR TITLE
Increased default timeout for mongodb to 10 seconds to accomodate slow connections, considering production replica sets and sharding.

### DIFF
--- a/limits/aio/storage/mongodb.py
+++ b/limits/aio/storage/mongodb.py
@@ -30,8 +30,8 @@ class MongoDBStorage(Storage, MovingWindowSupport):
     """
 
     DEFAULT_OPTIONS: Dict[str, Union[float, str, bool]] = {
-        "serverSelectionTimeoutMS": 1000,
-        "connectTimeoutMS": 1000,
+        "serverSelectionTimeoutMS": 10000,
+        "connectTimeoutMS": 10000,
     }
     "Default options passed to :class:`~motor.motor_asyncio.AsyncIOMotorClient`"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved database connection stability by increasing timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->