### PR TITLE
Correct the value of `reset_time` for MovingWindow strategy

### DIFF
--- a/limits/aio/storage/memory.py
+++ b/limits/aio/storage/memory.py
@@ -165,7 +165,7 @@ class MemoryStorage(Storage, MovingWindowSupport):
         timestamp = time.time()
         acquired = await self.get_num_acquired(key, expiry)
 
-        for item in self.events.get(key, []):
+        for item in self.events.get(key, [])[::-1]:
             if item.atime >= timestamp - expiry:
                 return int(item.atime), acquired
 

--- a/limits/aio/storage/mongodb.py
+++ b/limits/aio/storage/mongodb.py
@@ -227,7 +227,7 @@ class MongoDBStorage(Storage, MovingWindowSupport):
                 {
                     "$group": {
                         "_id": "$_id",
-                        "max": {"$max": "$entries"},
+                        "min": {"$min": "$entries"},
                         "count": {"$sum": 1},
                     }
                 },
@@ -235,7 +235,7 @@ class MongoDBStorage(Storage, MovingWindowSupport):
         ).to_list(length=1)
 
         if result:
-            return (int(result[0]["max"]), result[0]["count"])
+            return (int(result[0]["min"]), result[0]["count"])
 
         return (int(timestamp), 0)
 

--- a/limits/resources/redis/lua_scripts/moving_window.lua
+++ b/limits/resources/redis/lua_scripts/moving_window.lua
@@ -7,8 +7,9 @@ for idx=1,#items do
     if tonumber(items[idx]) >= expiry then
         a = a + 1
 
-        if oldest == nil then
-            oldest = tonumber(items[idx])
+        local value = tonumber(items[idx])
+        if oldest == nil or value < oldest then
+            oldest = value
         end
     else
         break

--- a/limits/storage/memory.py
+++ b/limits/storage/memory.py
@@ -155,7 +155,7 @@ class MemoryStorage(Storage, MovingWindowSupport):
         timestamp = time.time()
         acquired = self.get_num_acquired(key, expiry)
 
-        for item in self.events.get(key, []):
+        for item in self.events.get(key, [])[::-1]:
             if item.atime >= timestamp - expiry:
                 return int(item.atime), acquired
 

--- a/limits/storage/mongodb.py
+++ b/limits/storage/mongodb.py
@@ -198,7 +198,7 @@ class MongoDBStorage(Storage, MovingWindowSupport):
                     {
                         "$group": {
                             "_id": "$_id",
-                            "max": {"$max": "$entries"},
+                            "min": {"$min": "$entries"},
                             "count": {"$sum": 1},
                         }
                     },
@@ -207,7 +207,7 @@ class MongoDBStorage(Storage, MovingWindowSupport):
         )
 
         if result:
-            return int(result[0]["max"]), result[0]["count"]
+            return int(result[0]["min"]), result[0]["count"]
 
         return int(timestamp), 0
 

--- a/tests/aio/test_strategy.py
+++ b/tests/aio/test_strategy.py
@@ -121,7 +121,7 @@ class TestAsyncWindow:
         assert all([await limiter.hit(limit) for i in range(5)])
         assert (await limiter.get_window_stats(limit)).remaining == 0
         assert (await limiter.get_window_stats(limit)).reset_time == int(
-            time.time() + 1
+            time.time() + 2
         )
 
     @async_moving_window_storage

--- a/tests/aio/test_strategy.py
+++ b/tests/aio/test_strategy.py
@@ -120,9 +120,6 @@ class TestAsyncWindow:
         # 5 more succeed since there were only 5 in the last 2 seconds
         assert all([await limiter.hit(limit) for i in range(5)])
         assert (await limiter.get_window_stats(limit)).remaining == 0
-        assert (await limiter.get_window_stats(limit)).reset_time == int(
-            time.time() + 2
-        )
 
     @async_moving_window_storage
     async def test_moving_window_empty_stats(self, uri, args, fixture):

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -89,6 +89,21 @@ class TestWindow:
         assert limiter.get_window_stats(limit).reset_time == int(time.time() + 2)
 
     @moving_window_storage
+    def test_moving_window_stats(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = MovingWindowRateLimiter(storage)
+        limit = RateLimitItemPerMinute(2)
+        assert limiter.hit(limit, "key")
+        time.sleep(1)
+        assert limiter.hit(limit, "key")
+        time.sleep(1)
+        assert not limiter.hit(limit, "key")
+        assert limiter.get_window_stats(limit, "key").remaining == 0
+        assert (
+            limiter.get_window_stats(limit, "key").reset_time - int(time.time()) == 58
+        )
+
+    @moving_window_storage
     def test_moving_window(self, uri, args, fixture):
         storage = storage_from_string(uri, **args)
         limiter = MovingWindowRateLimiter(storage)


### PR DESCRIPTION
# Description
The value of `reset_time` for the moving window strategy is currently derived from the newest entry in the moving window instead of the oldest.

# Related issues
- #200 