### PR TITLE
Enable lazy init for mongoDB storage + add base class for easy reuse of MongoClient

### DIFF
--- a/limits/storage/__init__.py
+++ b/limits/storage/__init__.py
@@ -13,7 +13,7 @@ from .base import MovingWindowSupport, Storage
 from .etcd import EtcdStorage
 from .memcached import MemcachedStorage
 from .memory import MemoryStorage
-from .mongodb import MongoDBStorage
+from .mongodb import MongoDBStorage, MongoDBStorageBase
 from .redis import RedisStorage
 from .redis_cluster import RedisClusterStorage
 from .redis_sentinel import RedisSentinelStorage
@@ -68,6 +68,7 @@ __all__ = [
     "Storage",
     "MovingWindowSupport",
     "EtcdStorage",
+    "MongoDBStorageBase",
     "MemoryStorage",
     "MongoDBStorage",
     "RedisStorage",


### PR DESCRIPTION
1. Fix issue with UWSGI compatibility by using lazy-init
2. Expose a Base mongo storage that can be used (to reuse application level MongoClient)