### PR TITLE
Add cost parameter to test method in strategy

### DIFF
--- a/limits/aio/strategies.py
+++ b/limits/aio/strategies.py
@@ -36,6 +36,7 @@ class RateLimiter(ABC):
         :param item: the rate limit item
         :param identifiers: variable list of strings to uniquely identify the
          limit
+        :param cost: The expected cost to be consumed, default 1
         """
         raise NotImplementedError
 
@@ -93,6 +94,7 @@ class MovingWindowRateLimiter(RateLimiter):
         :param item: the rate limit item
         :param identifiers: variable list of strings to uniquely identify the
          limit
+        :param cost: The expected cost to be consumed, default 1
         """
         res = await cast(MovingWindowSupport, self.storage).get_moving_window(
             item.key_for(*identifiers),
@@ -154,6 +156,7 @@ class FixedWindowRateLimiter(RateLimiter):
         :param item: the rate limit item
         :param identifiers: variable list of strings to uniquely identify the
          limit
+        :param cost: The expected cost to be consumed, default 1
         """
 
         return (

--- a/limits/strategies.py
+++ b/limits/strategies.py
@@ -28,7 +28,7 @@ class RateLimiter(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def test(self, item: RateLimitItem, *identifiers: str) -> bool:
+    def test(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
         """
         Check the rate limit without consuming from it.
 
@@ -84,7 +84,7 @@ class MovingWindowRateLimiter(RateLimiter):
             item.key_for(*identifiers), item.amount, item.get_expiry(), amount=cost
         )
 
-    def test(self, item: RateLimitItem, *identifiers: str) -> bool:
+    def test(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
         """
         Check if the rate limit can be consumed
 
@@ -99,7 +99,7 @@ class MovingWindowRateLimiter(RateLimiter):
                 item.amount,
                 item.get_expiry(),
             )[1]
-            < item.amount
+            <= item.amount - cost
         )
 
     def get_window_stats(self, item: RateLimitItem, *identifiers: str) -> WindowStats:
@@ -144,7 +144,7 @@ class FixedWindowRateLimiter(RateLimiter):
             <= item.amount
         )
 
-    def test(self, item: RateLimitItem, *identifiers: str) -> bool:
+    def test(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
         """
         Check if the rate limit can be consumed
 
@@ -153,7 +153,7 @@ class FixedWindowRateLimiter(RateLimiter):
          instance of the limit
         """
 
-        return self.storage.get(item.key_for(*identifiers)) < item.amount
+        return self.storage.get(item.key_for(*identifiers)) < item.amount - cost + 1
 
     def get_window_stats(self, item: RateLimitItem, *identifiers: str) -> WindowStats:
         """

--- a/limits/strategies.py
+++ b/limits/strategies.py
@@ -35,6 +35,7 @@ class RateLimiter(metaclass=ABCMeta):
         :param item: The rate limit item
         :param identifiers: variable list of strings to uniquely identify this
           instance of the limit
+        :param cost: The expected cost to be consumed, default 1
         """
         raise NotImplementedError
 
@@ -91,6 +92,7 @@ class MovingWindowRateLimiter(RateLimiter):
         :param item: The rate limit item
         :param identifiers: variable list of strings to uniquely identify this
          instance of the limit
+        :param cost: The expected cost to be consumed, default 1
         """
 
         return (
@@ -151,6 +153,7 @@ class FixedWindowRateLimiter(RateLimiter):
         :param item: The rate limit item
         :param identifiers: variable list of strings to uniquely identify this
          instance of the limit
+        :param cost: The expected cost to be consumed, default 1
         """
 
         return self.storage.get(item.key_for(*identifiers)) < item.amount - cost + 1

--- a/tests/aio/test_strategy.py
+++ b/tests/aio/test_strategy.py
@@ -69,6 +69,7 @@ class TestAsyncWindow:
         assert not await limiter.hit(limit, "k1", cost=11)
         assert await limiter.hit(limit, "k2", cost=5)
         assert (await limiter.get_window_stats(limit, "k2")).remaining == 5
+        assert not await limiter.test(limit, "k2", cost=6)
         assert not await limiter.hit(limit, "k2", cost=6)
 
     @async_all_storage
@@ -143,9 +144,10 @@ class TestAsyncWindow:
             assert await limiter.hit(limit, "k2", cost=5)
         # 5 hits in the last 100ms
         async with async_window(2, delay=1.8):
-            assert all([await limiter.hit(limit, "k2") for i in range(5)])
-            # 11th fails
-            assert not await limiter.hit(limit, "k2")
+            assert all([await limiter.hit(limit, "k2") for i in range(4)])
+            assert not await limiter.test(limit, "k2", cost=2)
+            assert not await limiter.hit(limit, "k2", cost=2)
+            assert await limiter.hit(limit, "k2")
         assert all([await limiter.hit(limit, "k2") for i in range(5)])
         assert (await limiter.get_window_stats(limit, "k2")).remaining == 0
         assert not await limiter.hit(limit, "k2", cost=2)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -48,6 +48,7 @@ class TestWindow:
         assert not limiter.hit(limit, "k1", cost=11)
         assert limiter.hit(limit, "k2", cost=5)
         assert limiter.get_window_stats(limit, "k2").remaining == 5
+        assert not limiter.test(limit, "k2", cost=6)
         assert not limiter.hit(limit, "k2", cost=6)
 
     @all_storage
@@ -130,9 +131,10 @@ class TestWindow:
             limiter.hit(limit, "k2", cost=5)
         # 5 hits in the last 100ms
         with window(2, delay=1.8):
-            assert all(limiter.hit(limit, "k2") for i in range(5))
-            # 11th fails
-            assert not limiter.hit(limit, "k2")
+            assert all(limiter.hit(limit, "k2") for i in range(4))
+            assert not limiter.test(limit, "k2", cost=2)
+            assert not limiter.hit(limit, "k2", cost=2)
+            assert limiter.hit(limit, "k2")
 
         # 5 more succeed since there were only 5 in the last 2 seconds
         assert all([limiter.hit(limit, "k2") for i in range(5)])


### PR DESCRIPTION
# Description

Allow passing a `cost` parameter when using the `test` method in strategies. This can ensure that the 'test before hitting' approach works correctly with a cost > 1