### PR TITLE
Use importlib.resources from the standard library

### DIFF
--- a/limits/util.py
+++ b/limits/util.py
@@ -1,13 +1,13 @@
 """ """
 
 import dataclasses
+import importlib.resources
 import re
 import sys
 from collections import UserDict
 from types import ModuleType
 from typing import TYPE_CHECKING, cast
 
-import importlib_resources
 from packaging.version import Version
 
 from limits.typing import Dict, List, NamedTuple, Optional, Tuple, Type, Union
@@ -142,7 +142,7 @@ def get_dependency(module_path: str) -> Tuple[Optional[ModuleType], Optional[Ver
 
 
 def get_package_data(path: str) -> bytes:
-    return cast(bytes, importlib_resources.files("limits").joinpath(path).read_bytes())
+    return cast(bytes, importlib.resources.files("limits").joinpath(path).read_bytes())
 
 
 def parse_many(limit_string: str) -> List[RateLimitItem]:

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,4 +1,3 @@
 deprecated>=1.2
-importlib_resources>=1.3
 packaging>=21,<25
 typing_extensions


### PR DESCRIPTION
Since this package no longer supports Python < 3.7, it doesn't need to use the backport.