### PR TITLE
Implement ConcurrencyLimitRateLimiter strategy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,18 @@ Supported Strategies
    - Allow another request that arrives at ``00:01:00``
    - Reject the request that arrives at ``00:01:01``
 
+`Concurrency limit`
+
+   Limits the number of simultaneous or concurrent executions (or tokens in use)
+   without focusing on the rate of requests over time. It enforces a maximum
+   limit of tasks allowed to run in parallel.
+
+   For example, with a concurrency limit of 5:
+
+   - Allow up to 5 tasks or requests to be processed concurrently
+   - Reject any further requests until one of the 5 tasks completes and releases a slot
+   - Once a task finishes, the limit is reduced, allowing new tasks to be executed   
+
 Storage backends
 ================
 

--- a/doc/source/strategies.rst
+++ b/doc/source/strategies.rst
@@ -42,3 +42,15 @@ rate limit as the window for each limit is not fixed at the start and end of eac
 (i.e. N/second for a moving window means N in the last 1000 milliseconds). There is
 however a higher memory cost associated with this strategy as it requires ``N`` items to
 be maintained in memory per resource and rate limit.
+
+`Concurrency limit`
+
+Limits the number of simultaneous or concurrent executions (or tokens in use)
+without focusing on the rate of requests over time. It enforces a maximum
+limit of tasks allowed to run in parallel.
+
+For example, with a concurrency limit of 5:
+
+- Allow up to 5 tasks or requests to be processed concurrently
+- Reject any further requests until one of the 5 tasks completes and releases a slot
+- Once a task finishes, the limit is reduced, allowing new tasks to be executed   

--- a/limits/storage/memcached.py
+++ b/limits/storage/memcached.py
@@ -7,17 +7,8 @@ from typing import cast
 
 from limits.errors import ConfigurationError
 from limits.storage.base import Storage
-from limits.typing import (
-    Callable,
-    List,
-    MemcachedClientP,
-    Optional,
-    P,
-    R,
-    Tuple,
-    Type,
-    Union,
-)
+from limits.typing import (Callable, List, MemcachedClientP, Optional, P, R,
+                           Tuple, Type, Union)
 from limits.util import get_dependency
 
 


### PR DESCRIPTION
This PR adds support for a very basic rate limiting strategy called `concurrency limit` which sets a maximum number of concurrency per identifier and reject any request above that limit