### PR TITLE
Add a missing `import time` in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,7 @@ Test the limits
 
 .. code-block:: python
 
+    import time
     assert True == moving_window.hit(one_per_minute, "test_namespace", "foo")
     assert False == moving_window.hit(one_per_minute, "test_namespace", "foo")
     assert True == moving_window.hit(one_per_minute, "test_namespace", "bar")


### PR DESCRIPTION
**Fix: Add missing import in README**

This pull request addresses an issue where the README was missing an import statement, preventing users from running the example code as intended.
