### PR TITLE
Rewrite strategy documentation to improve correctness 

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,9 +17,11 @@
 
 ----
 
-*limits* is a python library to perform rate limiting with commonly used
-storage backends (Redis, Memcached & MongoDB).
+**limits** is a python library for rate limiting via multiple strategies
+with commonly used storage backends (Redis, Memcached, MongoDB & Etcd).
 
+The library provides identical APIs for use in sync and
+:ref:`async <async:async support>`  codebases.
 
 Get started by taking a look at :ref:`installation:installation` and :ref:`quickstart:quickstart`.
 

--- a/doc/source/strategies.rst
+++ b/doc/source/strategies.rst
@@ -108,38 +108,32 @@ For example, with a rate limit of ``100 requests per minute``
 
 Suppose:
 
-- Current bucket (:math:`C_{\text{current}}`) has 80 hits.
-- Previous bucket (:math:`C_{\text{prev}}`) has 40 hits.
+- Current bucket has 80 hits (:math:`C_{\text{current}}`)
+- Previous bucket has 40 hits (:math:`C_{\text{prev}}`)
 
-Scenario 1
-~~~~~~~~~~
+- If the bucket shifted 30 seconds ago (:math:`T_{\text{elapsed}} = 30`).
 
-The bucket shifted 30 seconds ago (:math:`T_{\text{elapsed}} = 30`).
+  .. math::
 
-.. math::
+    w = \frac{60 - 30}{60} = 0.5
 
-  w = \frac{60 - 30}{60} = 0.5
+  .. math::
 
-.. math::
+    C_{\text{weighted}} = \left\lfloor 80 + (0.5 \times 40) \right\rfloor = 100
 
-  C_{\text{weighted}} = \left\lfloor 80 + (0.5 \times 40) \right\rfloor = 100
+  Since the effective count equals the limit, a new request is rejected.
 
-Since the effective count equals the limit, a new request is rejected.
+- If the bucket shifted 40 seconds ago (:math:`T_{\text{elapsed}} = 40`).
 
-Scenario 2
-~~~~~~~~~~
+  .. math::
 
-The bucket shifted 40 seconds ago (:math:`T_{\text{elapsed}} = 40`).
+    w = \frac{60 - 40}{60} \approx 0.33
 
-.. math::
+  .. math::
 
-  w = \frac{60 - 40}{60} \approx 0.33
+    C_{\text{weighted}} = \left\lfloor 80 + (0.33 \times 40) \right\rfloor = 93
 
-.. math::
-
-  C_{\text{weighted}} = \left\lfloor 80 + (0.33 \times 40) \right\rfloor = 93
-
-Since the effective count is below the limit, a new request is allowed.
+  Since the effective count is below the limit, a new request is allowed.
 
 .. note::
    Some storage implementations use fixed bucket boundaries (e.g., aligning buckets with


### PR DESCRIPTION
# Description

- Remove ambiguity around window start/end for fixed windows
- Add consistent & concrete examples for all strategies
- Update README to be in sync with rtd documentation


Related issue: #250
Read the docs: https://limits.readthedocs.io/en/strategy-doc-revision/strategies.html