### PR TITLE
Use HTTPS for GitHub clone URL

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -55,7 +55,7 @@ To get started
 
 .. code:: console
 
-   $ git clone git://github.com/alisaifee/limits.git
+   $ git clone https://github.com/alisaifee/limits.git
    $ cd limits
    $ pip install -r requirements/dev.txt
 


### PR DESCRIPTION
GitHub has dropped support for the git:// protocol:
https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/