### PR TITLE
Remove upper bound from packaging requirement

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,3 +1,3 @@
 deprecated>=1.2
-packaging>=21,<26
+packaging>=21
 typing_extensions


### PR DESCRIPTION
There does not seem to be any documented incompatibility, and having arbitrary upper bounds on libraries causes incompatible version issues.