### PR TITLE
fix: Handle special characters in Redis cluster URL

### DIFF
--- a/tests/storage/test_redis_cluster.py
+++ b/tests/storage/test_redis_cluster.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from limits.storage.redis_cluster import RedisClusterStorage
+
+
+class TestRedisClusterStorageEncodePassword:
+    """Test encode_password_in_url static method"""
+
+    @pytest.mark.parametrize(
+        "input_url, expected_output",
+        [
+            # Test cases from the image
+            (
+                "redis+cluster://user:pass#word@localhost:7001",
+                "redis+cluster://user:pass%23word@localhost:7001",
+            ),
+            (
+                "redis+cluster://:pass#word@localhost:7001",
+                "redis+cluster://:pass%23word@localhost:7001",
+            ),
+            (
+                "redis+cluster://user:p@ss#w:rd@localhost:7001",
+                "redis+cluster://user:p%40ss%23w%3Ard@localhost:7001",
+            ),
+            # No authentication case - should remain unchanged
+            (
+                "redis+cluster://localhost:7001",
+                "redis+cluster://localhost:7001",
+            ),
+        ],
+    )
+    def test_encode_password_in_url(self, input_url, expected_output):
+        """Test encode_password_in_url encodes special characters correctly"""
+        result = RedisClusterStorage.encode_password_in_url(input_url)
+        assert result == expected_output
+
+    def test_encode_password_in_url_no_scheme(self):
+        """Test encode_password_in_url with URL without scheme"""
+        url = "localhost:7001"
+        result = RedisClusterStorage.encode_password_in_url(url)
+        assert result == url
+
+    def test_encode_password_in_url_no_auth(self):
+        """Test encode_password_in_url with URL without auth part"""
+        url = "redis+cluster://localhost:7001,localhost:7002"
+        result = RedisClusterStorage.encode_password_in_url(url)
+        assert result == url


### PR DESCRIPTION
## Problem

When initializing `RedisClusterStorage` with a URL containing passwords with special characters (such as `#`, `@`, `:`), the initialization fails because `urllib.parse.urlparse()` strictly follows RFC 3986, which requires these characters to be percent-encoded in URLs.

This is a common issue when using cloud-managed Redis services that generate passwords containing reserved characters that are not pre-encoded according to RFC 3986.

## Solution

This PR implements a minimal, non-intrusive fix by:

1. **Adding `encode_password_in_url()` static method**: Automatically encodes special characters in the password (and username) portion of the URL before parsing
2. **Updating `initialize_storage()`**: Uses the encoded URL for parsing, then decodes the credentials after extraction to preserve the original password value
3. **Maintaining backward compatibility**: The fix is transparent to users and doesn't change the API

## Design Decision

I considered alternative approaches such as:
- Providing multiple `__init__` methods with separate username/password parameters
- Requiring users to pre-encode their passwords

However, I chose this approach because:
- **URL is the primary semantic**: The URL is passed downstream to other methods, so maintaining URL-based initialization is essential
- **Minimal intrusion**: This solution requires the smallest possible change to existing code
- **User-friendly**: Users don't need to manually encode their passwords or change their code

## Testing

Added comprehensive tests covering:
- Passwords with `#`, `@`, `:` characters
- URLs without authentication
- URLs without scheme

## Example

Before this fix, a URL like:
```
redis+cluster://user:pass#word@localhost:7001
```
would fail to parse correctly. Now it works as expected.

