### PR TITLE
Add GCRA rate limiting strategy

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.13"
   commands:

--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,19 @@ Scenario 2:
 - Since the weighted count is below the limit, the request is allowed.
 
 
+GCRA
+----
+`GCRA <https://limits.readthedocs.io/en/latest/strategies.html#gcra>`_
+
+The Generic Cell Rate Algorithm tracks a theoretical arrival time for each
+rate limit key. Requests are accepted when that theoretical arrival time is
+within the configured burst tolerance, then the theoretical arrival time is
+advanced by the request cost multiplied by the continuous refill interval.
+
+By default, the burst tolerance is the rate limit amount. A smaller immediate
+burst can be configured by passing ``burst`` to ``GCRARateLimiter``.
+
+
 Storage backends
 ================
 
@@ -152,6 +165,10 @@ Initialize a rate limiter with a strategy
    strategy = strategies.FixedWindowRateLimiter(backend)
    # or sliding window
    strategy = strategies.SlidingWindowCounterRateLimiter(backend)
+   # or GCRA
+   strategy = strategies.GCRARateLimiter(backend)
+   # or GCRA with a smaller burst tolerance
+   strategy = strategies.GCRARateLimiter(backend, burst=10)
 
 
 Initialize a rate limit

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -30,6 +30,7 @@ Provided by :mod:`limits.strategies`
 .. autoclass:: FixedWindowRateLimiter
 .. autoclass:: MovingWindowRateLimiter
 .. autoclass:: SlidingWindowCounterRateLimiter
+.. autoclass:: GCRARateLimiter
 
 All strategies implement the same abstract base class:
 
@@ -48,6 +49,7 @@ Provided by :mod:`limits.aio.strategies`
 .. autoclass:: FixedWindowRateLimiter
 .. autoclass:: MovingWindowRateLimiter
 .. autoclass:: SlidingWindowCounterRateLimiter
+.. autoclass:: GCRARateLimiter
 
 All strategies implement the same abstract base class:
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -142,6 +142,7 @@ Abstract storage classes
 
 .. autoclass:: limits.storage.Storage
 .. autoclass:: limits.storage.MovingWindowSupport
+.. autoclass:: limits.storage.GCRASupport
 .. autoclass:: limits.storage.SlidingWindowCounterSupport
 
 
@@ -150,6 +151,7 @@ Async Abstract storage classes
 
 .. autoclass:: limits.aio.storage.Storage
 .. autoclass:: limits.aio.storage.MovingWindowSupport
+.. autoclass:: limits.aio.storage.GCRASupport
 .. autoclass:: limits.aio.storage.SlidingWindowCounterSupport
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -33,12 +34,22 @@ if branch_from_env := os.environ.get("READTHEDOCS_VERSION", None):
         "sha": os.environ.get("READTHEDOCS_GIT_COMMIT_HASH", ""),
     }
 else:
-    import limits._version
+    repository_root = Path(__file__).resolve().parents[2]
 
-    git_info = limits._version.git_pieces_from_vcs("", os.path.abspath("../../"), False)
+    def git_info(*args: str) -> str:
+        try:
+            return subprocess.check_output(
+                ["git", *args],
+                cwd=repository_root,
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        except (OSError, subprocess.CalledProcessError):
+            return ""
+
     benchmark_git_context = {
-        "branch": git_info.get("branch", ""),
-        "sha": git_info.get("long", None),
+        "branch": git_info("branch", "--show-current"),
+        "sha": git_info("rev-parse", "HEAD"),
     }
 benchmark_param_mapping = {
     "percentage_full": {

--- a/doc/source/custom-storage.rst
+++ b/doc/source/custom-storage.rst
@@ -21,6 +21,8 @@ Creating a custom backend requires:
        the methods from :class:`~limits.storage.MovingWindowSupport`
     #. If the storage can support the :ref:`strategies:sliding window counter` strategy – additionally implementing
        the methods from :class:`~limits.storage.SlidingWindowCounterSupport`
+    #. If the storage can support the :ref:`strategies:gcra` strategy – additionally implementing
+       the methods from :class:`~limits.storage.GCRASupport`
     #. Providing naming *schemes* that can be used to look up the custom storage in the storage registry.
        (Refer to :ref:`storage:storage scheme` for more details)
 
@@ -34,7 +36,12 @@ variables which result in the classes getting registered with the **limits** sto
     import time
     from urllib.parse import urlparse
     from typing import Tuple, Type, Union
-    from limits.storage import Storage, MovingWindowSupport, SlidingWindowCounterSupport
+    from limits.storage import (
+        GCRASupport,
+        MovingWindowSupport,
+        SlidingWindowCounterSupport,
+        Storage,
+    )
 
     class BasicStorage(Storage):
         """A simple fixed-window storage backend."""
@@ -66,7 +73,9 @@ variables which result in the classes getting registered with the **limits** sto
         def clear(self, key: str) -> None:
             pass
 
-    class AdvancedStorage(Storage, MovingWindowSupport, SlidingWindowCounterSupport):
+    class AdvancedStorage(
+        Storage, GCRASupport, MovingWindowSupport, SlidingWindowCounterSupport
+    ):
         """A more advanced storage backend supporting all rate-limiting strategies."""
         STORAGE_SCHEME = ["advanceddatabase"]
 
@@ -109,6 +118,23 @@ variables which result in the classes getting registered with the **limits** sto
 
         def get_sliding_window(self, key: str, expiry: int) -> Tuple[int, float, int, float]:
             return (0, expiry / 2, 0, expiry)
+
+        def clear_sliding_window(self, key: str, expiry: int) -> None:
+            pass
+
+        # --- GCRA Support ---
+        def acquire_gcra_entry(
+            self, key: str, limit: int, expiry: int, amount: int = 1, burst: int = 1
+        ) -> bool:
+            return True
+
+        def get_gcra_window(
+            self, key: str, limit: int, expiry: int, burst: int = 1
+        ) -> Tuple[float, int]:
+            return (time.time(), burst)
+
+        def clear_gcra_window(self, key: str) -> None:
+            pass
 
 Once the above implementations are declared, you can look them up
 using the :ref:`api:storage factory function` in the following manner::

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -16,7 +16,9 @@ Install the package with pip:
 
    Includes
 
-   .. literalinclude:: ../../requirements/storage/redis.txt
+   .. code:: text
+
+      redis>3,!=4.5.2,!=4.5.3,<8.0.0
 
 .. tab:: RedisCluster
 
@@ -26,7 +28,9 @@ Install the package with pip:
 
    Includes
 
-   .. literalinclude:: ../../requirements/storage/rediscluster.txt
+   .. code:: text
+
+      redis>=4.2.0,!=4.5.2,!=4.5.3
 
 .. tab:: Memcached
 
@@ -36,7 +40,9 @@ Install the package with pip:
 
    Includes
 
-   .. literalinclude:: ../../requirements/storage/memcached.txt
+   .. code:: text
+
+      pymemcache>3,<5.0.0
 
 .. tab:: MongoDB
 
@@ -46,7 +52,9 @@ Install the package with pip:
 
    Includes:
 
-   .. literalinclude:: ../../requirements/storage/mongodb.txt
+   .. code:: text
+
+      pymongo>4.1,<5
 
 .. tab:: Valkey
 
@@ -56,7 +64,9 @@ Install the package with pip:
 
    Includes:
 
-   .. literalinclude:: ../../requirements/storage/valkey.txt
+   .. code:: text
+
+      valkey>=6
 
 More details around the specifics of each storage backend can be
 found in :ref:`storage`
@@ -77,7 +87,9 @@ along with the package using the following extras:
 
    Includes:
 
-   .. literalinclude:: ../../requirements/storage/async-redis.txt
+   .. code:: text
+
+      coredis>=3.4.0,<6
 
    .. versionadded:: 4.2
       :pypi:`redis` if installed can be used instead of :pypi:`coredis` by setting
@@ -93,7 +105,9 @@ along with the package using the following extras:
 
    Includes:
 
-   .. literalinclude:: ../../requirements/storage/async-memcached.txt
+   .. code:: text
+
+      memcachio>=0.3
 
    .. versionchanged:: 5.0
       :pypi:`emcache` if installed can be used instead of the new default
@@ -108,7 +122,9 @@ along with the package using the following extras:
 
    Includes:
 
-   .. literalinclude:: ../../requirements/storage/async-mongodb.txt
+   .. code:: text
+
+      motor>=3,<4
 
 .. tab:: Valkey
 
@@ -118,6 +134,8 @@ along with the package using the following extras:
 
    Includes:
 
-   .. literalinclude:: ../../requirements/storage/async-valkey.txt
+   .. code:: text
+
+      valkey>=6
 
 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -66,6 +66,19 @@ Initialize a rate limiter
         from limits import strategies
         limiter = strategies.SlidingWindowCounterRateLimiter(limits_storage)
 
+.. tab:: With the GCRA strategy
+
+    .. caution:: If the storage used does not support the GCRA
+       strategy, :exc:`NotImplementedError` will be raised
+
+    .. code::
+
+        from limits import strategies
+        limiter = strategies.GCRARateLimiter(limits_storage)
+        limiter_with_smaller_burst = strategies.GCRARateLimiter(
+            limits_storage, burst=10
+        )
+
 Describe the rate limit
 =======================
 

--- a/doc/source/storage.rst
+++ b/doc/source/storage.rst
@@ -25,11 +25,15 @@ the results in `github <https://github.com/alisaifee/limits/actions/workflows/co
 
    Dependency versions:
 
-   .. literalinclude:: ../../requirements/storage/redis.txt
+   .. code:: text
+
+      redis>3,!=4.5.2,!=4.5.3,<8.0.0
 
    Dependency versions (async):
 
-   .. literalinclude:: ../../requirements/storage/async-redis.txt
+   .. code:: text
+
+      coredis>=3.4.0,<6
 
    .. note::
      .. versionadded:: 4.2
@@ -44,11 +48,15 @@ the results in `github <https://github.com/alisaifee/limits/actions/workflows/co
 
    Dependency versions:
 
-   .. literalinclude:: ../../requirements/storage/rediscluster.txt
+   .. code:: text
+
+      redis>=4.2.0,!=4.5.2,!=4.5.3
 
    Dependency versions (async):
 
-   .. literalinclude:: ../../requirements/storage/async-redis.txt
+   .. code:: text
+
+      coredis>=3.4.0,<6
 
    .. note::
       .. versionadded:: 4.2
@@ -63,11 +71,15 @@ the results in `github <https://github.com/alisaifee/limits/actions/workflows/co
 
    Dependency versions:
 
-   .. literalinclude:: ../../requirements/storage/memcached.txt
+   .. code:: text
+
+      pymemcache>3,<5.0.0
 
    Dependency versions (async):
 
-   .. literalinclude:: ../../requirements/storage/async-memcached.txt
+   .. code:: text
+
+      memcachio>=0.3
 
    `Memcached <https://memcached.org/>`_
 
@@ -77,11 +89,15 @@ the results in `github <https://github.com/alisaifee/limits/actions/workflows/co
 
    Dependency versions:
 
-   .. literalinclude:: ../../requirements/storage/mongodb.txt
+   .. code:: text
+
+      pymongo>4.1,<5
 
    Dependency versions (async):
 
-   .. literalinclude:: ../../requirements/storage/async-mongodb.txt
+   .. code:: text
+
+      motor>=3,<4
 
    `MongoDB <https://www.mongodb.com/>`_
 
@@ -91,11 +107,15 @@ the results in `github <https://github.com/alisaifee/limits/actions/workflows/co
 
    Dependency versions:
 
-   .. literalinclude:: ../../requirements/storage/valkey.txt
+   .. code:: text
+
+      valkey>=6
 
    Dependency versions (async):
 
-   .. literalinclude:: ../../requirements/storage/async-valkey.txt
+   .. code:: text
+
+      valkey>=6
 
    `Valkey <https://www.valkey.io/>`_
 

--- a/doc/source/strategies.rst
+++ b/doc/source/strategies.rst
@@ -17,6 +17,11 @@ TL;DR: How to choose a strategy
   smooths transitions between time periods with less overhead than a full moving window,
   though it may trade off some precision near bucket boundaries.
 
+- **GCRA:**
+  Use when a continuous refill rate and explicit burst tolerance are needed. This
+  strategy stores constant-size state and handles weighted hits without storing one
+  entry per unit of cost.
+
 Fixed Window
 ============
 
@@ -132,3 +137,30 @@ Suppose:
 
 
 
+
+
+GCRA
+====
+
+The Generic Cell Rate Algorithm (GCRA) tracks a theoretical arrival time for
+each rate limit key. A request is allowed when that theoretical arrival time is
+within the configured burst tolerance. If allowed, the theoretical arrival time
+is advanced by the request cost multiplied by the emission interval.
+
+The emission interval is calculated as:
+
+.. math::
+
+    T = \frac{T_{\text{exp}}}{N}
+
+Where :math:`T_{\text{exp}}` is the rate limit period and :math:`N` is the
+allowed amount for that period.
+
+By default, the burst tolerance is the rate limit amount. For example, a limit
+of ``100000 per month`` can accept a burst of ``100000`` immediately and then
+refills continuously at one unit every 25.92 seconds. A smaller burst can be
+configured by passing ``burst`` to :class:`limits.strategies.GCRARateLimiter`.
+
+This strategy is not equivalent to a moving window. After a full burst is
+accepted, GCRA starts refilling immediately, while a moving window waits for
+older request timestamps to leave the rolling window.

--- a/limits/aio/storage/__init__.py
+++ b/limits/aio/storage/__init__.py
@@ -5,7 +5,7 @@ Implementations of storage backends to be used with
 
 from __future__ import annotations
 
-from .base import MovingWindowSupport, SlidingWindowCounterSupport, Storage
+from .base import GCRASupport, MovingWindowSupport, SlidingWindowCounterSupport, Storage
 from .memcached import MemcachedStorage
 from .memory import MemoryStorage
 from .mongodb import MongoDBStorage
@@ -15,6 +15,7 @@ __all__ = [
     "MemcachedStorage",
     "MemoryStorage",
     "MongoDBStorage",
+    "GCRASupport",
     "MovingWindowSupport",
     "RedisClusterStorage",
     "RedisSentinelStorage",

--- a/limits/aio/storage/base.py
+++ b/limits/aio/storage/base.py
@@ -168,6 +168,71 @@ class MovingWindowSupport(ABC):
         raise NotImplementedError
 
 
+class GCRASupport(ABC):
+    """
+    Abstract base class for storages that support
+    the :ref:`strategies:gcra` strategy.
+    """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:  # type: ignore[explicit-any]
+        for method in {
+            "acquire_gcra_entry",
+            "get_gcra_window",
+            "clear_gcra_window",
+        }:
+            setattr(
+                cls,
+                method,
+                _wrap_errors(getattr(cls, method)),
+            )
+        super().__init_subclass__(**kwargs)
+
+    @abstractmethod
+    async def acquire_gcra_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+        burst: int = 1,
+    ) -> bool:
+        """
+        Acquire an entry if the theoretical arrival time is within the burst
+        tolerance.
+
+        :param key: rate limit key to acquire an entry in
+        :param limit: amount of entries allowed over the expiry period
+        :param expiry: expiry period of the limit
+        :param amount: the number of entries to acquire
+        :param burst: the maximum amount that can be acquired immediately
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_gcra_window(
+        self, key: str, limit: int, expiry: int, burst: int = 1
+    ) -> tuple[float, int]:
+        """
+        Return the next reset time and remaining burst capacity for the GCRA
+        limit.
+
+        :param key: rate limit key
+        :param limit: amount of entries allowed over the expiry period
+        :param expiry: expiry period of the limit
+        :param burst: the maximum amount that can be acquired immediately
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def clear_gcra_window(self, key: str) -> None:
+        """
+        Resets the GCRA rate limit key.
+
+        :param key: the key to clear rate limits for
+        """
+        ...
+
+
 class SlidingWindowCounterSupport(ABC):
     """
     Abstract base class for async storages that support

--- a/limits/aio/storage/memory.py
+++ b/limits/aio/storage/memory.py
@@ -4,12 +4,13 @@ import asyncio
 import bisect
 import time
 from collections import Counter, defaultdict
-from math import floor
+from math import ceil, floor
 
 from deprecated.sphinx import versionadded
 
 import limits.typing
 from limits.aio.storage.base import (
+    GCRASupport,
     MovingWindowSupport,
     SlidingWindowCounterSupport,
     Storage,
@@ -25,7 +26,11 @@ class Entry:
 
 @versionadded(version="2.1")
 class MemoryStorage(
-    Storage, MovingWindowSupport, SlidingWindowCounterSupport, TimestampedSlidingWindow
+    Storage,
+    GCRASupport,
+    MovingWindowSupport,
+    SlidingWindowCounterSupport,
+    TimestampedSlidingWindow,
 ):
     """
     rate limit storage using :class:`collections.Counter`
@@ -46,6 +51,7 @@ class MemoryStorage(
         self.locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
         self.expirations: dict[str, float] = {}
         self.events: dict[str, list[Entry]] = {}
+        self.gcra: dict[str, float] = {}
         self.timer: asyncio.Task[None] | None = None
         super().__init__(uri, wrap_exceptions=wrap_exceptions, **_)
 
@@ -77,6 +83,11 @@ class MemoryStorage(
                     if not self.events.get(key, None):
                         self.events.pop(key, None)
                         self.locks.pop(key, None)
+
+            for key in list(self.gcra.keys()):
+                if self.gcra[key] <= time.time():
+                    self.gcra.pop(key, None)
+                    self.locks.pop(key, None)
 
             for key in list(self.expirations.keys()):
                 if self.expirations[key] <= time.time():
@@ -143,6 +154,7 @@ class MemoryStorage(
         self.storage.pop(key, None)
         self.expirations.pop(key, None)
         self.events.pop(key, None)
+        self.gcra.pop(key, None)
         self.locks.pop(key, None)
 
     async def acquire_entry(
@@ -198,6 +210,47 @@ class MemoryStorage(
             )
             return events[oldest - 1].atime, oldest
         return timestamp, 0
+
+    async def acquire_gcra_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+        burst: int = 1,
+    ) -> bool:
+        if amount > burst:
+            return False
+
+        emission_interval = expiry / limit
+        tolerance = burst * emission_interval
+        now = time.time()
+        async with self.locks[key]:
+            tat = max(self.gcra.get(key, now), now)
+            new_tat = tat + amount * emission_interval
+            if new_tat - tolerance > now:
+                return False
+            self.gcra[key] = new_tat
+            await self.__schedule_expiry()
+            return True
+
+    async def get_gcra_window(
+        self, key: str, limit: int, expiry: int, burst: int = 1
+    ) -> tuple[float, int]:
+        emission_interval = expiry / limit
+        tolerance = (burst - 1) * emission_interval
+        now = time.time()
+        tat = self.gcra.get(key, now)
+        if tat <= now:
+            return now, burst
+
+        used = min(burst, ceil((tat - now) / emission_interval))
+        remaining = max(0, burst - used)
+        reset = now if remaining else tat - tolerance
+        return reset, remaining
+
+    async def clear_gcra_window(self, key: str) -> None:
+        self.gcra.pop(key, None)
 
     async def acquire_sliding_window_entry(
         self,
@@ -271,10 +324,11 @@ class MemoryStorage(
         return True
 
     async def reset(self) -> int | None:
-        num_items = max(len(self.storage), len(self.events))
+        num_items = max(len(self.storage), len(self.events), len(self.gcra))
         self.storage.clear()
         self.expirations.clear()
         self.events.clear()
+        self.gcra.clear()
         self.locks.clear()
 
         return num_items

--- a/limits/aio/storage/redis/__init__.py
+++ b/limits/aio/storage/redis/__init__.py
@@ -5,7 +5,12 @@ import asyncio
 from deprecated.sphinx import versionadded, versionchanged
 from packaging.version import Version
 
-from limits.aio.storage import MovingWindowSupport, SlidingWindowCounterSupport, Storage
+from limits.aio.storage import (
+    GCRASupport,
+    MovingWindowSupport,
+    SlidingWindowCounterSupport,
+    Storage,
+)
 from limits.aio.storage.redis.bridge import RedisBridge
 from limits.aio.storage.redis.coredis import CoredisBridge
 from limits.aio.storage.redis.redispy import RedispyBridge
@@ -29,7 +34,9 @@ from limits.typing import Literal
         " ``async+valkey`` schema"
     ),
 )
-class RedisStorage(Storage, MovingWindowSupport, SlidingWindowCounterSupport):
+class RedisStorage(
+    Storage, GCRASupport, MovingWindowSupport, SlidingWindowCounterSupport
+):
     """
     Rate limit storage with redis as backend.
 
@@ -200,6 +207,24 @@ class RedisStorage(Storage, MovingWindowSupport, SlidingWindowCounterSupport):
         :return: (previous count, previous TTL, current count, current TTL)
         """
         return await self.bridge.get_moving_window(key, limit, expiry)
+
+    async def acquire_gcra_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+        burst: int = 1,
+    ) -> bool:
+        return await self.bridge.acquire_gcra_entry(key, limit, expiry, amount, burst)
+
+    async def get_gcra_window(
+        self, key: str, limit: int, expiry: int, burst: int = 1
+    ) -> tuple[float, int]:
+        return await self.bridge.get_gcra_window(key, limit, expiry, burst)
+
+    async def clear_gcra_window(self, key: str) -> None:
+        await self.bridge.clear_gcra_window(key)
 
     async def acquire_sliding_window_entry(
         self,

--- a/limits/aio/storage/redis/bridge.py
+++ b/limits/aio/storage/redis/bridge.py
@@ -16,6 +16,8 @@ class RedisBridge(ABC):
     )
     SCRIPT_CLEAR_KEYS = get_package_data(f"{RES_DIR}/clear_keys.lua")
     SCRIPT_INCR_EXPIRE = get_package_data(f"{RES_DIR}/incr_expire.lua")
+    SCRIPT_GCRA_WINDOW = get_package_data(f"{RES_DIR}/gcra_window.lua")
+    SCRIPT_ACQUIRE_GCRA = get_package_data(f"{RES_DIR}/acquire_gcra.lua")
     SCRIPT_SLIDING_WINDOW = get_package_data(f"{RES_DIR}/sliding_window.lua")
     SCRIPT_ACQUIRE_SLIDING_WINDOW = get_package_data(
         f"{RES_DIR}/acquire_sliding_window.lua"
@@ -83,6 +85,24 @@ class RedisBridge(ABC):
     async def get_moving_window(
         self, key: str, limit: int, expiry: int
     ) -> tuple[float, int]: ...
+
+    @abstractmethod
+    async def get_gcra_window(
+        self, key: str, limit: int, expiry: int, burst: int = 1
+    ) -> tuple[float, int]: ...
+
+    @abstractmethod
+    async def acquire_gcra_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+        burst: int = 1,
+    ) -> bool: ...
+
+    @abstractmethod
+    async def clear_gcra_window(self, key: str) -> None: ...
 
     @abstractmethod
     async def get_sliding_window(

--- a/limits/aio/storage/redis/coredis.py
+++ b/limits/aio/storage/redis/coredis.py
@@ -83,6 +83,8 @@ class CoredisBridge(RedisBridge):
 
     lua_moving_window: coredis.commands.Script[bytes]
     lua_acquire_moving_window: coredis.commands.Script[bytes]
+    lua_gcra_window: coredis.commands.Script[bytes]
+    lua_acquire_gcra: coredis.commands.Script[bytes]
     lua_sliding_window: coredis.commands.Script[bytes]
     lua_acquire_sliding_window: coredis.commands.Script[bytes]
     lua_clear_keys: coredis.commands.Script[bytes]
@@ -104,6 +106,12 @@ class CoredisBridge(RedisBridge):
         )
         self.lua_incr_expire = self.get_connection().register_script(
             self.SCRIPT_INCR_EXPIRE
+        )
+        self.lua_gcra_window = self.get_connection().register_script(
+            self.SCRIPT_GCRA_WINDOW
+        )
+        self.lua_acquire_gcra = self.get_connection().register_script(
+            self.SCRIPT_ACQUIRE_GCRA
         )
         self.lua_sliding_window = self.get_connection().register_script(
             self.SCRIPT_SLIDING_WINDOW
@@ -140,6 +148,37 @@ class CoredisBridge(RedisBridge):
         if window:
             return float(window[0]), window[1]  # type: ignore
         return timestamp, 0
+
+    async def get_gcra_window(
+        self, key: str, limit: int, expiry: int, burst: int = 1
+    ) -> tuple[float, int]:
+        key = self.prefixed_key(key)
+        timestamp = time.time()
+        window = await self.lua_gcra_window.execute(
+            [key], [timestamp, limit, expiry, burst]
+        )
+        if window:
+            return float(window[0]), int(window[1])  # type: ignore
+        return timestamp, burst
+
+    async def acquire_gcra_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+        burst: int = 1,
+    ) -> bool:
+        key = self.prefixed_key(key)
+        timestamp = time.time()
+        acquired = await self.lua_acquire_gcra.execute(
+            [key], [timestamp, limit, expiry, amount, burst]
+        )
+
+        return bool(acquired)
+
+    async def clear_gcra_window(self, key: str) -> None:
+        await self.clear(key)
 
     async def get_sliding_window(
         self, previous_key: str, current_key: str, expiry: int

--- a/limits/aio/storage/redis/redispy.py
+++ b/limits/aio/storage/redis/redispy.py
@@ -88,6 +88,8 @@ class RedispyBridge(RedisBridge):
 
     lua_moving_window: redis.commands.core.Script
     lua_acquire_moving_window: redis.commands.core.Script
+    lua_gcra_window: redis.commands.core.Script
+    lua_acquire_gcra: redis.commands.core.Script
     lua_sliding_window: redis.commands.core.Script
     lua_acquire_sliding_window: redis.commands.core.Script
     lua_clear_keys: redis.commands.core.Script
@@ -110,6 +112,12 @@ class RedispyBridge(RedisBridge):
         )
         self.lua_incr_expire = self.get_connection().register_script(
             self.SCRIPT_INCR_EXPIRE
+        )
+        self.lua_gcra_window = self.get_connection().register_script(
+            self.SCRIPT_GCRA_WINDOW
+        )
+        self.lua_acquire_gcra = self.get_connection().register_script(
+            self.SCRIPT_ACQUIRE_GCRA
         )
         self.lua_sliding_window = self.get_connection().register_script(
             self.SCRIPT_SLIDING_WINDOW
@@ -172,6 +180,35 @@ class RedispyBridge(RedisBridge):
         if window:
             return float(window[0]), window[1]
         return timestamp, 0
+
+    async def get_gcra_window(
+        self, key: str, limit: int, expiry: int, burst: int = 1
+    ) -> tuple[float, int]:
+        key = self.prefixed_key(key)
+        timestamp = time.time()
+        window = await self.lua_gcra_window([key], [timestamp, limit, expiry, burst])
+        if window:
+            return float(window[0]), int(window[1])
+        return timestamp, burst
+
+    async def acquire_gcra_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+        burst: int = 1,
+    ) -> bool:
+        key = self.prefixed_key(key)
+        timestamp = time.time()
+        acquired = await self.lua_acquire_gcra(
+            [key], [timestamp, limit, expiry, amount, burst]
+        )
+
+        return bool(acquired)
+
+    async def clear_gcra_window(self, key: str) -> None:
+        await self.clear(key)
 
     async def get_sliding_window(
         self, previous_key: str, current_key: str, expiry: int

--- a/limits/aio/strategies.py
+++ b/limits/aio/strategies.py
@@ -15,7 +15,7 @@ from ..storage import StorageTypes
 from ..typing import cast
 from ..util import WindowStats
 from .storage import MovingWindowSupport, Storage
-from .storage.base import SlidingWindowCounterSupport
+from .storage.base import GCRASupport, SlidingWindowCounterSupport
 
 
 class RateLimiter(ABC):
@@ -201,6 +201,62 @@ class FixedWindowRateLimiter(RateLimiter):
         return WindowStats(reset, remaining)
 
 
+class GCRARateLimiter(RateLimiter):
+    """
+    Reference: :ref:`strategies:gcra`
+    """
+
+    def __init__(self, storage: StorageTypes, burst: int | None = None):
+        if not hasattr(storage, "get_gcra_window") or not hasattr(
+            storage, "acquire_gcra_entry"
+        ):
+            raise NotImplementedError(
+                "GCRARateLimiting is not implemented for storage "
+                f"of type {storage.__class__}"
+            )
+        if burst is not None and burst < 1:
+            raise ValueError("burst must be at least 1")
+        self.burst = burst
+        super().__init__(storage)
+
+    def _burst(self, item: RateLimitItem) -> int:
+        return self.burst or item.amount
+
+    async def hit(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
+        return await cast(GCRASupport, self.storage).acquire_gcra_entry(
+            item.key_for(*identifiers),
+            item.amount,
+            item.get_expiry(),
+            amount=cost,
+            burst=self._burst(item),
+        )
+
+    async def test(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
+        _, remaining = await cast(GCRASupport, self.storage).get_gcra_window(
+            item.key_for(*identifiers),
+            item.amount,
+            item.get_expiry(),
+            burst=self._burst(item),
+        )
+        return remaining >= cost
+
+    async def get_window_stats(
+        self, item: RateLimitItem, *identifiers: str
+    ) -> WindowStats:
+        reset, remaining = await cast(GCRASupport, self.storage).get_gcra_window(
+            item.key_for(*identifiers),
+            item.amount,
+            item.get_expiry(),
+            burst=self._burst(item),
+        )
+        return WindowStats(reset, remaining)
+
+    async def clear(self, item: RateLimitItem, *identifiers: str) -> None:
+        return await cast(GCRASupport, self.storage).clear_gcra_window(
+            item.key_for(*identifiers)
+        )
+
+
 @versionadded(version="4.1")
 class SlidingWindowCounterRateLimiter(RateLimiter):
     """
@@ -328,4 +384,5 @@ STRATEGIES = {
     "sliding-window-counter": SlidingWindowCounterRateLimiter,
     "fixed-window": FixedWindowRateLimiter,
     "moving-window": MovingWindowRateLimiter,
+    "gcra": GCRARateLimiter,
 }

--- a/limits/resources/redis/lua_scripts/acquire_gcra.lua
+++ b/limits/resources/redis/lua_scripts/acquire_gcra.lua
@@ -1,0 +1,27 @@
+local timestamp = tonumber(ARGV[1])
+local limit = tonumber(ARGV[2])
+local expiry = tonumber(ARGV[3])
+local amount = tonumber(ARGV[4])
+local burst = tonumber(ARGV[5])
+
+if amount > burst then
+    return false
+end
+
+local emission_interval = expiry / limit
+local tolerance = burst * emission_interval
+local tat = tonumber(redis.call('get', KEYS[1])) or timestamp
+
+if tat < timestamp then
+    tat = timestamp
+end
+
+local new_tat = tat + amount * emission_interval
+if new_tat - tolerance > timestamp then
+    return false
+end
+
+redis.call('set', KEYS[1], tostring(new_tat))
+redis.call('expire', KEYS[1], math.max(1, math.ceil(new_tat - timestamp)))
+
+return true

--- a/limits/resources/redis/lua_scripts/gcra_window.lua
+++ b/limits/resources/redis/lua_scripts/gcra_window.lua
@@ -1,0 +1,21 @@
+local timestamp = tonumber(ARGV[1])
+local limit = tonumber(ARGV[2])
+local expiry = tonumber(ARGV[3])
+local burst = tonumber(ARGV[4])
+
+local emission_interval = expiry / limit
+local tolerance = (burst - 1) * emission_interval
+local tat = tonumber(redis.call('get', KEYS[1])) or timestamp
+
+if tat <= timestamp then
+    return {tostring(timestamp), burst}
+end
+
+local used = math.min(burst, math.ceil((tat - timestamp) / emission_interval))
+local remaining = math.max(0, burst - used)
+local reset = timestamp
+if remaining == 0 then
+    reset = tat - tolerance
+end
+
+return {tostring(reset), remaining}

--- a/limits/storage/__init__.py
+++ b/limits/storage/__init__.py
@@ -12,7 +12,7 @@ import limits  # noqa
 from .._storage_scheme import SCHEMES
 from ..errors import ConfigurationError
 from ..typing import TypeAlias, cast
-from .base import MovingWindowSupport, SlidingWindowCounterSupport, Storage
+from .base import GCRASupport, MovingWindowSupport, SlidingWindowCounterSupport, Storage
 from .memcached import MemcachedStorage
 from .memory import MemoryStorage
 from .mongodb import MongoDBStorage, MongoDBStorageBase
@@ -70,6 +70,7 @@ __all__ = [
     "MemoryStorage",
     "MongoDBStorage",
     "MongoDBStorageBase",
+    "GCRASupport",
     "MovingWindowSupport",
     "RedisClusterStorage",
     "RedisSentinelStorage",

--- a/limits/storage/base.py
+++ b/limits/storage/base.py
@@ -160,6 +160,71 @@ class MovingWindowSupport(ABC):
         raise NotImplementedError
 
 
+class GCRASupport(ABC):
+    """
+    Abstract base class for storages that support
+    the :ref:`strategies:gcra` strategy.
+    """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:  # type: ignore[explicit-any]
+        for method in {
+            "acquire_gcra_entry",
+            "get_gcra_window",
+            "clear_gcra_window",
+        }:
+            setattr(
+                cls,
+                method,
+                _wrap_errors(getattr(cls, method)),
+            )
+        super().__init_subclass__(**kwargs)
+
+    @abstractmethod
+    def acquire_gcra_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+        burst: int = 1,
+    ) -> bool:
+        """
+        Acquire an entry if the theoretical arrival time is within the burst
+        tolerance.
+
+        :param key: rate limit key to acquire an entry in
+        :param limit: amount of entries allowed over the expiry period
+        :param expiry: expiry period of the limit
+        :param amount: the number of entries to acquire
+        :param burst: the maximum amount that can be acquired immediately
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_gcra_window(
+        self, key: str, limit: int, expiry: int, burst: int = 1
+    ) -> tuple[float, int]:
+        """
+        Return the next reset time and remaining burst capacity for the GCRA
+        limit.
+
+        :param key: rate limit key
+        :param limit: amount of entries allowed over the expiry period
+        :param expiry: expiry period of the limit
+        :param burst: the maximum amount that can be acquired immediately
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def clear_gcra_window(self, key: str) -> None:
+        """
+        Resets the GCRA rate limit key.
+
+        :param key: the key to clear rate limits for
+        """
+        ...
+
+
 class SlidingWindowCounterSupport(ABC):
     """
     Abstract base class for storages that support

--- a/limits/storage/memory.py
+++ b/limits/storage/memory.py
@@ -4,10 +4,11 @@ import bisect
 import threading
 import time
 from collections import Counter, defaultdict
-from math import floor
+from math import ceil, floor
 
 import limits.typing
 from limits.storage.base import (
+    GCRASupport,
     MovingWindowSupport,
     SlidingWindowCounterSupport,
     Storage,
@@ -22,7 +23,11 @@ class Entry:
 
 
 class MemoryStorage(
-    Storage, MovingWindowSupport, SlidingWindowCounterSupport, TimestampedSlidingWindow
+    Storage,
+    GCRASupport,
+    MovingWindowSupport,
+    SlidingWindowCounterSupport,
+    TimestampedSlidingWindow,
 ):
     """
     rate limit storage using :class:`collections.Counter`
@@ -38,6 +43,7 @@ class MemoryStorage(
         self.locks: defaultdict[str, threading.RLock] = defaultdict(threading.RLock)
         self.expirations: dict[str, float] = {}
         self.events: dict[str, list[Entry]] = {}
+        self.gcra: dict[str, float] = {}
         self.timer: threading.Timer = threading.Timer(0.01, self.__expire_events)
         self.timer.start()
         super().__init__(uri, wrap_exceptions=wrap_exceptions, **_)
@@ -64,6 +70,10 @@ class MemoryStorage(
                     self.events[key] = self.events[key][:oldest]
                 if not self.events.get(key, None):
                     self.locks.pop(key, None)
+        for key in list(self.gcra.keys()):
+            if self.gcra[key] <= time.time():
+                self.gcra.pop(key, None)
+                self.locks.pop(key, None)
         for key in list(self.expirations.keys()):
             if self.expirations[key] <= time.time():
                 self.storage.pop(key, None)
@@ -130,6 +140,7 @@ class MemoryStorage(
         self.storage.pop(key, None)
         self.expirations.pop(key, None)
         self.events.pop(key, None)
+        self.gcra.pop(key, None)
         self.locks.pop(key, None)
 
     def acquire_entry(self, key: str, limit: int, expiry: int, amount: int = 1) -> bool:
@@ -180,6 +191,47 @@ class MemoryStorage(
             )
             return events[oldest - 1].atime, oldest
         return timestamp, 0
+
+    def acquire_gcra_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+        burst: int = 1,
+    ) -> bool:
+        if amount > burst:
+            return False
+
+        emission_interval = expiry / limit
+        tolerance = burst * emission_interval
+        now = time.time()
+        with self.locks[key]:
+            tat = max(self.gcra.get(key, now), now)
+            new_tat = tat + amount * emission_interval
+            if new_tat - tolerance > now:
+                return False
+            self.gcra[key] = new_tat
+            self.__schedule_expiry()
+            return True
+
+    def get_gcra_window(
+        self, key: str, limit: int, expiry: int, burst: int = 1
+    ) -> tuple[float, int]:
+        emission_interval = expiry / limit
+        tolerance = (burst - 1) * emission_interval
+        now = time.time()
+        tat = self.gcra.get(key, now)
+        if tat <= now:
+            return now, burst
+
+        used = min(burst, ceil((tat - now) / emission_interval))
+        remaining = max(0, burst - used)
+        reset = now if remaining else tat - tolerance
+        return reset, remaining
+
+    def clear_gcra_window(self, key: str) -> None:
+        self.gcra.pop(key, None)
 
     def acquire_sliding_window_entry(
         self,
@@ -251,9 +303,10 @@ class MemoryStorage(
         return True
 
     def reset(self) -> int | None:
-        num_items = max(len(self.storage), len(self.events))
+        num_items = max(len(self.storage), len(self.events), len(self.gcra))
         self.storage.clear()
         self.expirations.clear()
         self.events.clear()
+        self.gcra.clear()
         self.locks.clear()
         return num_items

--- a/limits/storage/redis.py
+++ b/limits/storage/redis.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 from limits.typing import Literal, RedisClient
 
 from ..util import get_package_data
-from .base import MovingWindowSupport, SlidingWindowCounterSupport, Storage
+from .base import GCRASupport, MovingWindowSupport, SlidingWindowCounterSupport, Storage
 
 if TYPE_CHECKING:
     import redis
@@ -22,7 +22,9 @@ if TYPE_CHECKING:
         " if :paramref:`uri` has the ``valkey://`` schema"
     ),
 )
-class RedisStorage(Storage, MovingWindowSupport, SlidingWindowCounterSupport):
+class RedisStorage(
+    Storage, GCRASupport, MovingWindowSupport, SlidingWindowCounterSupport
+):
     """
     Rate limit storage with redis as backend.
 
@@ -50,6 +52,8 @@ class RedisStorage(Storage, MovingWindowSupport, SlidingWindowCounterSupport):
     )
     SCRIPT_CLEAR_KEYS = get_package_data(f"{RES_DIR}/clear_keys.lua")
     SCRIPT_INCR_EXPIRE = get_package_data(f"{RES_DIR}/incr_expire.lua")
+    SCRIPT_GCRA_WINDOW = get_package_data(f"{RES_DIR}/gcra_window.lua")
+    SCRIPT_ACQUIRE_GCRA = get_package_data(f"{RES_DIR}/acquire_gcra.lua")
 
     SCRIPT_SLIDING_WINDOW = get_package_data(f"{RES_DIR}/sliding_window.lua")
     SCRIPT_ACQUIRE_SLIDING_WINDOW = get_package_data(
@@ -58,6 +62,8 @@ class RedisStorage(Storage, MovingWindowSupport, SlidingWindowCounterSupport):
 
     lua_moving_window: redis.commands.core.Script
     lua_acquire_moving_window: redis.commands.core.Script
+    lua_gcra_window: redis.commands.core.Script
+    lua_acquire_gcra: redis.commands.core.Script
     lua_sliding_window: redis.commands.core.Script
     lua_acquire_sliding_window: redis.commands.core.Script
 
@@ -133,6 +139,12 @@ class RedisStorage(Storage, MovingWindowSupport, SlidingWindowCounterSupport):
         self.lua_incr_expire = self.get_connection().register_script(
             self.SCRIPT_INCR_EXPIRE
         )
+        self.lua_gcra_window = self.get_connection().register_script(
+            self.SCRIPT_GCRA_WINDOW
+        )
+        self.lua_acquire_gcra = self.get_connection().register_script(
+            self.SCRIPT_ACQUIRE_GCRA
+        )
         self.lua_sliding_window = self.get_connection().register_script(
             self.SCRIPT_SLIDING_WINDOW
         )
@@ -185,6 +197,35 @@ class RedisStorage(Storage, MovingWindowSupport, SlidingWindowCounterSupport):
             return float(window[0]), window[1]
 
         return timestamp, 0
+
+    def get_gcra_window(
+        self, key: str, limit: int, expiry: int, burst: int = 1
+    ) -> tuple[float, int]:
+        key = self.prefixed_key(key)
+        timestamp = time.time()
+        if window := self.lua_gcra_window([key], [timestamp, limit, expiry, burst]):
+            return float(window[0]), int(window[1])
+
+        return timestamp, burst
+
+    def acquire_gcra_entry(
+        self,
+        key: str,
+        limit: int,
+        expiry: int,
+        amount: int = 1,
+        burst: int = 1,
+    ) -> bool:
+        key = self.prefixed_key(key)
+        timestamp = time.time()
+        acquired = self.lua_acquire_gcra(
+            [key], [timestamp, limit, expiry, amount, burst]
+        )
+
+        return bool(acquired)
+
+    def clear_gcra_window(self, key: str) -> None:
+        self.clear(key)
 
     def get_sliding_window(
         self, key: str, expiry: int

--- a/limits/strategies.py
+++ b/limits/strategies.py
@@ -10,7 +10,7 @@ from math import floor, inf
 
 from deprecated.sphinx import versionadded
 
-from limits.storage.base import SlidingWindowCounterSupport
+from limits.storage.base import GCRASupport, SlidingWindowCounterSupport
 
 from .limits import RateLimitItem
 from .storage import MovingWindowSupport, Storage, StorageTypes
@@ -191,6 +191,60 @@ class FixedWindowRateLimiter(RateLimiter):
         return WindowStats(reset, remaining)
 
 
+class GCRARateLimiter(RateLimiter):
+    """
+    Reference: :ref:`strategies:gcra`
+    """
+
+    def __init__(self, storage: StorageTypes, burst: int | None = None):
+        if not hasattr(storage, "get_gcra_window") or not hasattr(
+            storage, "acquire_gcra_entry"
+        ):
+            raise NotImplementedError(
+                "GCRARateLimiting is not implemented for storage "
+                f"of type {storage.__class__}"
+            )
+        if burst is not None and burst < 1:
+            raise ValueError("burst must be at least 1")
+        self.burst = burst
+        super().__init__(storage)
+
+    def _burst(self, item: RateLimitItem) -> int:
+        return self.burst or item.amount
+
+    def hit(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
+        return cast(GCRASupport, self.storage).acquire_gcra_entry(
+            item.key_for(*identifiers),
+            item.amount,
+            item.get_expiry(),
+            amount=cost,
+            burst=self._burst(item),
+        )
+
+    def test(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
+        _, remaining = cast(GCRASupport, self.storage).get_gcra_window(
+            item.key_for(*identifiers),
+            item.amount,
+            item.get_expiry(),
+            burst=self._burst(item),
+        )
+        return remaining >= cost
+
+    def get_window_stats(self, item: RateLimitItem, *identifiers: str) -> WindowStats:
+        reset, remaining = cast(GCRASupport, self.storage).get_gcra_window(
+            item.key_for(*identifiers),
+            item.amount,
+            item.get_expiry(),
+            burst=self._burst(item),
+        )
+        return WindowStats(reset, remaining)
+
+    def clear(self, item: RateLimitItem, *identifiers: str) -> None:
+        return cast(GCRASupport, self.storage).clear_gcra_window(
+            item.key_for(*identifiers)
+        )
+
+
 @versionadded(version="4.1")
 class SlidingWindowCounterRateLimiter(RateLimiter):
     """
@@ -309,10 +363,12 @@ KnownStrategy = (
     type[SlidingWindowCounterRateLimiter]
     | type[FixedWindowRateLimiter]
     | type[MovingWindowRateLimiter]
+    | type[GCRARateLimiter]
 )
 
 STRATEGIES: dict[str, KnownStrategy] = {
     "sliding-window-counter": SlidingWindowCounterRateLimiter,
     "fixed-window": FixedWindowRateLimiter,
     "moving-window": MovingWindowRateLimiter,
+    "gcra": GCRARateLimiter,
 }

--- a/tests/aio/test_strategy.py
+++ b/tests/aio/test_strategy.py
@@ -7,6 +7,7 @@ import pytest
 
 from limits.aio.strategies import (
     FixedWindowRateLimiter,
+    GCRARateLimiter,
     MovingWindowRateLimiter,
     SlidingWindowCounterRateLimiter,
 )
@@ -20,6 +21,7 @@ from limits.storage.base import TimestampedSlidingWindow
 from tests.utils import (
     async_all_storage,
     async_fixed_start,
+    async_gcra_storage,
     async_moving_window_storage,
     async_sliding_window_counter_storage,
     async_window,
@@ -75,6 +77,66 @@ class TestAsyncFixedWindow:
         assert await limiter.hit(limit)
         assert not await limiter.test(limit)
         assert not await limiter.hit(limit)
+
+
+@pytest.mark.asyncio
+@async_gcra_storage
+class TestAsyncGCRA:
+    async def test_gcra_default_burst(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = GCRARateLimiter(storage)
+        limit = RateLimitItemPerSecond(10, 2)
+
+        assert all([await limiter.hit(limit, "key") for _ in range(10)])
+        assert not await limiter.hit(limit, "key")
+        stats = await limiter.get_window_stats(limit, "key")
+        assert stats.remaining == 0
+        assert stats.reset_time - time.time() == pytest.approx(0.2, abs=0.1)
+        time.sleep(0.25)
+        assert await limiter.hit(limit, "key")
+
+    async def test_gcra_custom_burst(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = GCRARateLimiter(storage, burst=3)
+        limit = RateLimitItemPerSecond(10, 2)
+
+        assert all([await limiter.hit(limit, "key") for _ in range(3)])
+        assert not await limiter.hit(limit, "key")
+        assert not await limiter.hit(limit, "other", cost=4)
+
+    async def test_gcra_multiple_cost(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = GCRARateLimiter(storage)
+        limit = RateLimitItemPerSecond(10, 2)
+
+        assert not await limiter.hit(limit, "too-much", cost=11)
+        assert await limiter.hit(limit, "key", cost=5)
+        assert (await limiter.get_window_stats(limit, "key")).remaining == 5
+        assert not await limiter.test(limit, "key", cost=6)
+        assert not await limiter.hit(limit, "key", cost=6)
+        assert await limiter.hit(limit, "key", cost=5)
+        assert (await limiter.get_window_stats(limit, "key")).remaining == 0
+
+    async def test_gcra_test_does_not_consume(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = GCRARateLimiter(storage)
+        limit = RateLimitItemPerSecond(10, 2)
+
+        assert await limiter.test(limit, "key", cost=10)
+        assert await limiter.test(limit, "key", cost=10)
+        assert await limiter.hit(limit, "key", cost=10)
+        assert not await limiter.test(limit, "key")
+
+    async def test_gcra_clear(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = GCRARateLimiter(storage, burst=3)
+        limit = RateLimitItemPerSecond(10, 2)
+
+        assert await limiter.hit(limit, "key", cost=3)
+        assert not await limiter.hit(limit, "key")
+        await limiter.clear(limit, "key")
+        assert (await limiter.get_window_stats(limit, "key")).remaining == 3
+        assert await limiter.hit(limit, "key", cost=3)
 
 
 @pytest.mark.asyncio

--- a/tests/aio/test_strategy.py
+++ b/tests/aio/test_strategy.py
@@ -91,7 +91,8 @@ class TestAsyncGCRA:
         assert not await limiter.hit(limit, "key")
         stats = await limiter.get_window_stats(limit, "key")
         assert stats.remaining == 0
-        assert stats.reset_time - time.time() == pytest.approx(0.2, abs=0.1)
+        reset_in = stats.reset_time - time.time()
+        assert 0 <= reset_in <= 0.25
         time.sleep(0.25)
         assert await limiter.hit(limit, "key")
 

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -52,6 +52,11 @@ def pytest_benchmark_generate_json(
                         | limits.aio.strategies.SlidingWindowCounterRateLimiter
                     ):
                         bench.params[name] = "sliding-window"
+                    case (
+                        limits.strategies.GCRARateLimiter
+                        | limits.aio.strategies.GCRARateLimiter
+                    ):
+                        bench.params[name] = "gcra"
             if name == "uri":
                 scheme = limits.storage.storage_from_string(param).STORAGE_SCHEME[0]
                 bench.params["async"] = "async" in scheme

--- a/tests/benchmarks/test_storage.py
+++ b/tests/benchmarks/test_storage.py
@@ -11,6 +11,7 @@ from limits import RateLimitItem, RateLimitItemPerDay, RateLimitItemPerMinute
 from limits.storage import storage_from_string
 from limits.strategies import (
     FixedWindowRateLimiter,
+    GCRARateLimiter,
     MovingWindowRateLimiter,
     RateLimiter,
     SlidingWindowCounterRateLimiter,
@@ -118,8 +119,9 @@ def seed_limit(
         FixedWindowRateLimiter,
         SlidingWindowCounterRateLimiter,
         MovingWindowRateLimiter,
+        GCRARateLimiter,
     ],
-    ids=["fixed-window", "sliding-window", "moving-window"],
+    ids=["fixed-window", "sliding-window", "moving-window", "gcra"],
 )
 @pytest.mark.parametrize("percentage_full", [5, 50, 95])
 def test_hit(benchmark, strategy, uri, args, limit, percentage_full, fixture):
@@ -139,8 +141,9 @@ def test_hit(benchmark, strategy, uri, args, limit, percentage_full, fixture):
         FixedWindowRateLimiter,
         SlidingWindowCounterRateLimiter,
         MovingWindowRateLimiter,
+        GCRARateLimiter,
     ],
-    ids=["fixed-window", "sliding-window", "moving-window"],
+    ids=["fixed-window", "sliding-window", "moving-window", "gcra"],
 )
 @pytest.mark.parametrize("percentage_full", [5, 50, 95])
 @pytest.mark.benchmark(group="get-window-stats")
@@ -163,8 +166,9 @@ def test_get_window_stats(
         FixedWindowRateLimiter,
         SlidingWindowCounterRateLimiter,
         MovingWindowRateLimiter,
+        GCRARateLimiter,
     ],
-    ids=["fixed-window", "sliding-window", "moving-window"],
+    ids=["fixed-window", "sliding-window", "moving-window", "gcra"],
 )
 @pytest.mark.parametrize("percentage_full", [5, 50, 95])
 @pytest.mark.benchmark(group="test")
@@ -185,8 +189,9 @@ def test_test(benchmark, strategy, uri, args, limit, percentage_full, fixture):
         limits.aio.strategies.FixedWindowRateLimiter,
         limits.aio.strategies.SlidingWindowCounterRateLimiter,
         limits.aio.strategies.MovingWindowRateLimiter,
+        limits.aio.strategies.GCRARateLimiter,
     ],
-    ids=["fixed-window", "sliding-window", "moving-window"],
+    ids=["fixed-window", "sliding-window", "moving-window", "gcra"],
 )
 @pytest.mark.parametrize("percentage_full", [5, 50, 95])
 @pytest.mark.benchmark(group="hit")
@@ -214,8 +219,9 @@ def test_hit_async(benchmark, strategy, uri, args, limit, percentage_full, fixtu
         limits.aio.strategies.FixedWindowRateLimiter,
         limits.aio.strategies.SlidingWindowCounterRateLimiter,
         limits.aio.strategies.MovingWindowRateLimiter,
+        limits.aio.strategies.GCRARateLimiter,
     ],
-    ids=["fixed-window", "sliding-window", "moving-window"],
+    ids=["fixed-window", "sliding-window", "moving-window", "gcra"],
 )
 @pytest.mark.parametrize("percentage_full", [5, 50, 95])
 @pytest.mark.benchmark(group="get-window-stats")
@@ -245,8 +251,9 @@ def test_get_window_stats_async(
         limits.aio.strategies.FixedWindowRateLimiter,
         limits.aio.strategies.SlidingWindowCounterRateLimiter,
         limits.aio.strategies.MovingWindowRateLimiter,
+        limits.aio.strategies.GCRARateLimiter,
     ],
-    ids=["fixed-window", "sliding-window", "moving-window"],
+    ids=["fixed-window", "sliding-window", "moving-window", "gcra"],
 )
 @pytest.mark.parametrize("percentage_full", [5, 50, 95])
 @pytest.mark.benchmark(group="test")

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -14,12 +14,14 @@ from limits.storage import storage_from_string
 from limits.storage.base import TimestampedSlidingWindow
 from limits.strategies import (
     FixedWindowRateLimiter,
+    GCRARateLimiter,
     MovingWindowRateLimiter,
     SlidingWindowCounterRateLimiter,
 )
 from tests.utils import (
     all_storage,
     fixed_start,
+    gcra_storage,
     moving_window_storage,
     sliding_window_counter_storage,
     timestamp_based_key_ttl,
@@ -74,6 +76,65 @@ class TestFixedWindow:
         assert limiter.hit(limit)
         assert not limiter.test(limit)
         assert not limiter.hit(limit)
+
+
+@gcra_storage
+class TestGCRA:
+    def test_gcra_default_burst(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = GCRARateLimiter(storage)
+        limit = RateLimitItemPerSecond(10, 2)
+
+        assert all(limiter.hit(limit, "key") for _ in range(10))
+        assert not limiter.hit(limit, "key")
+        stats = limiter.get_window_stats(limit, "key")
+        assert stats.remaining == 0
+        assert stats.reset_time - time.time() == pytest.approx(0.2, abs=0.1)
+        time.sleep(0.25)
+        assert limiter.hit(limit, "key")
+
+    def test_gcra_custom_burst(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = GCRARateLimiter(storage, burst=3)
+        limit = RateLimitItemPerSecond(10, 2)
+
+        assert all(limiter.hit(limit, "key") for _ in range(3))
+        assert not limiter.hit(limit, "key")
+        assert not limiter.hit(limit, "other", cost=4)
+
+    def test_gcra_multiple_cost(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = GCRARateLimiter(storage)
+        limit = RateLimitItemPerSecond(10, 2)
+
+        assert not limiter.hit(limit, "too-much", cost=11)
+        assert limiter.hit(limit, "key", cost=5)
+        assert limiter.get_window_stats(limit, "key").remaining == 5
+        assert not limiter.test(limit, "key", cost=6)
+        assert not limiter.hit(limit, "key", cost=6)
+        assert limiter.hit(limit, "key", cost=5)
+        assert limiter.get_window_stats(limit, "key").remaining == 0
+
+    def test_gcra_test_does_not_consume(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = GCRARateLimiter(storage)
+        limit = RateLimitItemPerSecond(10, 2)
+
+        assert limiter.test(limit, "key", cost=10)
+        assert limiter.test(limit, "key", cost=10)
+        assert limiter.hit(limit, "key", cost=10)
+        assert not limiter.test(limit, "key")
+
+    def test_gcra_clear(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = GCRARateLimiter(storage, burst=3)
+        limit = RateLimitItemPerSecond(10, 2)
+
+        assert limiter.hit(limit, "key", cost=3)
+        assert not limiter.hit(limit, "key")
+        limiter.clear(limit, "key")
+        assert limiter.get_window_stats(limit, "key").remaining == 3
+        assert limiter.hit(limit, "key", cost=3)
 
 
 @sliding_window_counter_storage

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -89,7 +89,8 @@ class TestGCRA:
         assert not limiter.hit(limit, "key")
         stats = limiter.get_window_stats(limit, "key")
         assert stats.remaining == 0
-        assert stats.reset_time - time.time() == pytest.approx(0.2, abs=0.1)
+        reset_in = stats.reset_time - time.time()
+        assert 0 <= reset_in <= 0.25
         time.sleep(0.25)
         assert limiter.hit(limit, "key")
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -303,3 +303,23 @@ async_moving_window_storage = pytest.mark.parametrize(
 async_sliding_window_counter_storage = pytest.mark.parametrize(
     "uri, args, fixture", ALL_STORAGES_ASYNC.values()
 )
+
+
+gcra_storage = pytest.mark.parametrize(
+    "uri, args, fixture",
+    [
+        storage
+        for name, storage in ALL_STORAGES.items()
+        if name in {"memory", "redis", "redis-cluster", "redis-sentinel", "valkey"}
+    ],
+)
+
+
+async_gcra_storage = pytest.mark.parametrize(
+    "uri, args, fixture",
+    [
+        storage
+        for name, storage in ALL_STORAGES_ASYNC.items()
+        if name in {"memory", "redis", "redis-cluster", "redis-sentinel", "valkey"}
+    ],
+)


### PR DESCRIPTION
## Summary
Adds a GCRA rate limiting strategy with configurable burst tolerance.

Includes memory, Redis/Valkey, and async Redis storage support, plus docs and benchmarks.

## Note
GCRA stores one theoretical-arrival timestamp per key, which keeps weighted or long-window limits cheaper than moving-window storage. It uses continuous refill semantics, so it is not an exact moving-window replacement.