### PR TITLE
Reject negative rate limit costs

### DIFF
--- a/limits/aio/strategies.py
+++ b/limits/aio/strategies.py
@@ -23,6 +23,11 @@ class RateLimiter(ABC):
         assert isinstance(storage, Storage)
         self.storage: Storage = storage
 
+    @staticmethod
+    def _validate_cost(cost: int) -> None:
+        if cost < 0:
+            raise ValueError("cost must be greater than or equal to 0")
+
     @abstractmethod
     async def hit(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
         """
@@ -96,6 +101,7 @@ class MovingWindowRateLimiter(RateLimiter):
         :return: True if ``cost`` could be deducted from the rate limit without exceeding it
         """
 
+        self._validate_cost(cost)
         return await cast(MovingWindowSupport, self.storage).acquire_entry(
             item.key_for(*identifiers), item.amount, item.get_expiry(), amount=cost
         )
@@ -111,6 +117,7 @@ class MovingWindowRateLimiter(RateLimiter):
 
         :return: True if the rate limit is not depleted
         """
+        self._validate_cost(cost)
         res = await cast(MovingWindowSupport, self.storage).get_moving_window(
             item.key_for(*identifiers),
             item.amount,
@@ -156,6 +163,7 @@ class FixedWindowRateLimiter(RateLimiter):
         :return: True if ``cost`` could be deducted from the rate limit without exceeding it
         """
 
+        self._validate_cost(cost)
         return (
             await self.storage.incr(
                 item.key_for(*identifiers),
@@ -177,6 +185,7 @@ class FixedWindowRateLimiter(RateLimiter):
         :return: True if the rate limit is not depleted
         """
 
+        self._validate_cost(cost)
         return (
             await self.storage.get(item.key_for(*identifiers)) < item.amount - cost + 1
         )
@@ -240,6 +249,7 @@ class SlidingWindowCounterRateLimiter(RateLimiter):
 
         :return: True if ``cost`` could be deducted from the rate limit without exceeding it
         """
+        self._validate_cost(cost)
         return await cast(
             SlidingWindowCounterSupport, self.storage
         ).acquire_sliding_window_entry(
@@ -261,6 +271,7 @@ class SlidingWindowCounterRateLimiter(RateLimiter):
         :return: True if the rate limit is not depleted
         """
 
+        self._validate_cost(cost)
         previous_count, previous_expires_in, current_count, _ = await cast(
             SlidingWindowCounterSupport, self.storage
         ).get_sliding_window(item.key_for(*identifiers), item.get_expiry())

--- a/limits/strategies.py
+++ b/limits/strategies.py
@@ -23,6 +23,11 @@ class RateLimiter(metaclass=ABCMeta):
         assert isinstance(storage, Storage)
         self.storage: Storage = storage
 
+    @staticmethod
+    def _validate_cost(cost: int) -> None:
+        if cost < 0:
+            raise ValueError("cost must be greater than or equal to 0")
+
     @abstractmethod
     def hit(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
         """
@@ -94,6 +99,7 @@ class MovingWindowRateLimiter(RateLimiter):
         :return: True if ``cost`` could be deducted from the rate limit without exceeding it
         """
 
+        self._validate_cost(cost)
         return cast(MovingWindowSupport, self.storage).acquire_entry(
             item.key_for(*identifiers), item.amount, item.get_expiry(), amount=cost
         )
@@ -110,6 +116,7 @@ class MovingWindowRateLimiter(RateLimiter):
         :return: True if the rate limit is not depleted
         """
 
+        self._validate_cost(cost)
         return (
             cast(MovingWindowSupport, self.storage).get_moving_window(
                 item.key_for(*identifiers),
@@ -153,6 +160,7 @@ class FixedWindowRateLimiter(RateLimiter):
         :return: True if ``cost`` could be deducted from the rate limit without exceeding it
         """
 
+        self._validate_cost(cost)
         return (
             self.storage.incr(
                 item.key_for(*identifiers),
@@ -174,6 +182,7 @@ class FixedWindowRateLimiter(RateLimiter):
         :return: True if the rate limit is not depleted
         """
 
+        self._validate_cost(cost)
         return self.storage.get(item.key_for(*identifiers)) < item.amount - cost + 1
 
     def get_window_stats(self, item: RateLimitItem, *identifiers: str) -> WindowStats:
@@ -230,6 +239,7 @@ class SlidingWindowCounterRateLimiter(RateLimiter):
 
         :return: True if ``cost`` could be deducted from the rate limit without exceeding it
         """
+        self._validate_cost(cost)
         return cast(
             SlidingWindowCounterSupport, self.storage
         ).acquire_sliding_window_entry(
@@ -250,6 +260,7 @@ class SlidingWindowCounterRateLimiter(RateLimiter):
 
         :return: True if the rate limit is not depleted
         """
+        self._validate_cost(cost)
         previous_count, previous_expires_in, current_count, _ = cast(
             SlidingWindowCounterSupport, self.storage
         ).get_sliding_window(item.key_for(*identifiers), item.get_expiry())

--- a/tests/aio/test_strategy.py
+++ b/tests/aio/test_strategy.py
@@ -10,6 +10,7 @@ from limits.aio.strategies import (
     MovingWindowRateLimiter,
     SlidingWindowCounterRateLimiter,
 )
+from limits.aio.storage import MemoryStorage as AsyncMemoryStorage
 from limits.limits import (
     RateLimitItemPerHour,
     RateLimitItemPerMinute,
@@ -25,6 +26,30 @@ from tests.utils import (
     async_window,
     timestamp_based_key_ttl,
 )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "strategy_cls",
+    [
+        FixedWindowRateLimiter,
+        MovingWindowRateLimiter,
+        SlidingWindowCounterRateLimiter,
+    ],
+)
+@pytest.mark.parametrize("cost", [-1])
+async def test_invalid_cost_is_rejected(strategy_cls, cost):
+    storage = AsyncMemoryStorage()
+    limiter = strategy_cls(storage)
+    limit = RateLimitItemPerSecond(2, 1)
+
+    with pytest.raises(ValueError, match="cost must be greater than or equal to 0"):
+        await limiter.test(limit, "invalid-cost", cost=cost)
+
+    with pytest.raises(ValueError, match="cost must be greater than or equal to 0"):
+        await limiter.hit(limit, "invalid-cost", cost=cost)
+
+    assert (await limiter.get_window_stats(limit, "invalid-cost")).remaining == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -10,7 +10,7 @@ from limits.limits import (
     RateLimitItemPerMinute,
     RateLimitItemPerSecond,
 )
-from limits.storage import storage_from_string
+from limits.storage import MemoryStorage, storage_from_string
 from limits.storage.base import TimestampedSlidingWindow
 from limits.strategies import (
     FixedWindowRateLimiter,
@@ -25,6 +25,29 @@ from tests.utils import (
     timestamp_based_key_ttl,
     window,
 )
+
+
+@pytest.mark.parametrize(
+    "strategy_cls",
+    [
+        FixedWindowRateLimiter,
+        MovingWindowRateLimiter,
+        SlidingWindowCounterRateLimiter,
+    ],
+)
+@pytest.mark.parametrize("cost", [-1])
+def test_invalid_cost_is_rejected(strategy_cls, cost):
+    storage = MemoryStorage()
+    limiter = strategy_cls(storage)
+    limit = RateLimitItemPerSecond(2, 1)
+
+    with pytest.raises(ValueError, match="cost must be greater than or equal to 0"):
+        limiter.test(limit, "invalid-cost", cost=cost)
+
+    with pytest.raises(ValueError, match="cost must be greater than or equal to 0"):
+        limiter.hit(limit, "invalid-cost", cost=cost)
+
+    assert limiter.get_window_stats(limit, "invalid-cost").remaining == 2
 
 
 @all_storage


### PR DESCRIPTION
## Summary

Hi Ali-Akber, first of all thank you for maintaining `limits`.

I noticed that negative `cost` values are currently not rejected before strategy evaluation. With the in-memory fixed-window and sliding-window-counter strategies, passing `cost=-1` can increase the apparent remaining quota instead of consuming it.

This PR adds a small shared validation step in the sync and async `RateLimiter` base classes and applies it consistently before `hit()` / `test()` strategy logic.

The change deliberately preserves the existing `cost=0` no-op behavior and only rejects `cost < 0`.

## What changed

- Reject negative `cost` values with `ValueError`
- Apply validation in sync and async strategies
- Add regression tests for:
  - `FixedWindowRateLimiter`
  - `MovingWindowRateLimiter`
  - `SlidingWindowCounterRateLimiter`
  - sync and async variants
  - no state mutation after invalid calls

## Local verification

```
.venv/bin/ruff check limits/strategies.py limits/aio/strategies.py tests/test_strategy.py tests/aio/test_strategy.py
.venv/bin/pytest tests/test_strategy.py -k invalid_cost_is_rejected -q
.venv/bin/pytest tests/aio/test_strategy.py -k invalid_cost_is_rejected -q
.venv/bin/pytest tests/test_strategy.py -m memory -q
.venv/bin/pytest tests/aio/test_strategy.py -m memory -q
```