### PR TITLE
Implement ConcurrencyLimitRateLimiter strategy

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.13"
   commands:

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,9 @@ All strategies support the follow methods:
 - `test <https://limits.readthedocs.io/en/stable/api.html#limits.strategies.RateLimiter.test>`_: check if a request is allowed.
 - `get_window_stats <https://limits.readthedocs.io/en/stable/api.html#limits.strategies.RateLimiter.get_window_stats>`_: retrieve remaining quota and reset time.
 
+The Concurrency Limit strategy additionally exposes a ``release`` method to hand back an
+acquired slot once the in-flight request or task completes.
+
 Fixed Window
 ------------
 `Fixed Window <https://limits.readthedocs.io/en/latest/strategies.html#fixed-window>`_
@@ -113,6 +116,25 @@ Scenario 2:
 - ``weight = (60 - 40) / 60 ≈ 0.33``.
 - ``weighted_count = floor(8 + (4 * 0.33)) = floor(8 + 1.32) = 9``.
 - Since the weighted count is below the limit, the request is allowed.
+
+Concurrency Limit
+-----------------
+`Concurrency Limit <https://limits.readthedocs.io/en/latest/strategies.html#concurrency-limit>`_
+
+This strategy bounds the number of requests that are *in-flight at the same time* rather
+than the number allowed within a time period. A slot is acquired with ``hit`` and held
+until it is handed back with ``release``, making it a good fit for limiting concurrent
+workers, connections or seats.
+
+For example, with a concurrency limit of 3:
+
+- Three requests call ``hit`` and acquire all 3 slots. The resource is now at capacity.
+- A fourth request calls ``hit`` and is rejected without consuming a slot.
+- One of the in-flight requests calls ``release``, freeing a slot, and a subsequent
+  ``hit`` can acquire it.
+
+Each acquired slot carries a safety expiry so that slots leaked by callers that never
+release are eventually reclaimed.
 
 
 Storage backends

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -30,6 +30,7 @@ Provided by :mod:`limits.strategies`
 .. autoclass:: FixedWindowRateLimiter
 .. autoclass:: MovingWindowRateLimiter
 .. autoclass:: SlidingWindowCounterRateLimiter
+.. autoclass:: ConcurrencyLimitRateLimiter
 
 All strategies implement the same abstract base class:
 
@@ -48,6 +49,7 @@ Provided by :mod:`limits.aio.strategies`
 .. autoclass:: FixedWindowRateLimiter
 .. autoclass:: MovingWindowRateLimiter
 .. autoclass:: SlidingWindowCounterRateLimiter
+.. autoclass:: ConcurrencyLimitRateLimiter
 
 All strategies implement the same abstract base class:
 

--- a/doc/source/strategies.rst
+++ b/doc/source/strategies.rst
@@ -17,6 +17,12 @@ TL;DR: How to choose a strategy
   smooths transitions between time periods with less overhead than a full moving window,
   though it may trade off some precision near bucket boundaries.
 
+- **Concurrency Limit:**
+  Use when you need to bound the number of requests or tasks running *at the same
+  time* (in-flight concurrency) rather than the number allowed within a time period.
+  Unlike the window based strategies, slots are held until they are explicitly
+  released.
+
 Fixed Window
 ============
 
@@ -129,6 +135,38 @@ Suppose:
    clock intervals), while others adjust buckets dynamically based on the first hit.
    This difference can allow an attacker to bypass limits during the initial sampling
    period. The affected implementations are ``memcached`` and ``in-memory``.
+
+
+Concurrency Limit
+=================
+
+Unlike the window based strategies above, the concurrency limit does not bound the
+number of requests over a period of time; it bounds the number of requests (or tasks)
+that are **in-flight simultaneously**. A slot is acquired with
+:meth:`~limits.strategies.ConcurrencyLimitRateLimiter.hit` and held until it is given
+back with :meth:`~limits.strategies.ConcurrencyLimitRateLimiter.release`. This is a good
+fit for protecting a resource with a limited number of concurrent workers, connections
+or seats.
+
+For example, with a concurrency limit of 3:
+
+- A request calls ``hit`` and acquires slot 1 of 3. It starts processing.
+- Two more requests call ``hit`` and acquire slots 2 and 3. The resource is now at
+  capacity.
+- A fourth request calls ``hit``. Since all 3 slots are held, it is rejected and no slot
+  is consumed.
+- One of the first three requests finishes and calls ``release``, freeing a slot. A
+  subsequent ``hit`` can now acquire it.
+
+Because a caller may fail to release a slot (for example if the process crashes), each
+acquired slot carries a safety expiry derived from the rate limit's period so that
+leaked slots are eventually reclaimed.
+
+.. note::
+   The concurrency limit requires a storage backend that supports decrementing a
+   counter (:class:`~limits.storage.base.ConcurrencyLimitSupport`). Instantiating
+   :class:`~limits.strategies.ConcurrencyLimitRateLimiter` with an unsupported storage
+   raises :exc:`NotImplementedError`.
 
 
 

--- a/limits/aio/storage/base.py
+++ b/limits/aio/storage/base.py
@@ -232,3 +232,33 @@ class SlidingWindowCounterSupport(ABC):
         :param expiry: the rate limit expiry, needed to compute the key in some implemenations
         """
         ...
+
+
+class ConcurrencyLimitSupport(ABC):
+    """
+    Abstract base class for storages that support
+    the :ref:`strategies:concurrency limit` strategy.
+    """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:  # type: ignore[explicit-any]
+        for method in {
+            "decr",
+        }:
+            setattr(
+                cls,
+                method,
+                _wrap_errors(getattr(cls, method)),
+            )
+        super().__init_subclass__(**kwargs)
+
+    @abstractmethod
+    async def decr(self, key: str, amount: int = 1) -> int:
+        """
+        decrements the counter for a given rate limit key. The counter is
+        floored at zero so that a release can never take it below the number
+        of currently held slots.
+
+        :param key: the key to decrement
+        :param amount: the number to decrement by
+        """
+        raise NotImplementedError

--- a/limits/aio/storage/memory.py
+++ b/limits/aio/storage/memory.py
@@ -10,6 +10,7 @@ from deprecated.sphinx import versionadded
 
 import limits.typing
 from limits.aio.storage.base import (
+    ConcurrencyLimitSupport,
     MovingWindowSupport,
     SlidingWindowCounterSupport,
     Storage,
@@ -25,7 +26,11 @@ class Entry:
 
 @versionadded(version="2.1")
 class MemoryStorage(
-    Storage, MovingWindowSupport, SlidingWindowCounterSupport, TimestampedSlidingWindow
+    Storage,
+    MovingWindowSupport,
+    SlidingWindowCounterSupport,
+    ConcurrencyLimitSupport,
+    TimestampedSlidingWindow,
 ):
     """
     rate limit storage using :class:`collections.Counter`

--- a/limits/aio/strategies.py
+++ b/limits/aio/strategies.py
@@ -15,7 +15,7 @@ from ..storage import StorageTypes
 from ..typing import cast
 from ..util import WindowStats
 from .storage import MovingWindowSupport, Storage
-from .storage.base import SlidingWindowCounterSupport
+from .storage.base import ConcurrencyLimitSupport, SlidingWindowCounterSupport
 
 
 class RateLimiter(ABC):
@@ -324,8 +324,94 @@ class SlidingWindowCounterRateLimiter(RateLimiter):
         ).clear_sliding_window(item.key_for(*identifiers), item.get_expiry())
 
 
+@versionadded(version="5.9")
+class ConcurrencyLimitRateLimiter(RateLimiter):
+    """
+    Reference: :ref:`strategies:concurrency limit`
+    """
+
+    def __init__(self, storage: StorageTypes):
+        if not hasattr(storage, "decr"):
+            raise NotImplementedError(
+                "ConcurrencyLimiting is not implemented for storage "
+                f"of type {storage.__class__}"
+            )
+        super().__init__(storage)
+
+    async def hit(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
+        """
+        Acquire ``cost`` concurrency slots if doing so does not exceed the
+        limit. Slots are held until :meth:`release` is called (a safety expiry
+        of ``item.get_expiry()`` guards against slots leaked by callers that
+        never release).
+
+        :param item: The rate limit item
+        :param identifiers: variable list of strings to uniquely identify this
+         instance of the limit
+        :param cost: The number of slots to acquire, default 1
+
+        :return: True if the slots could be acquired without exceeding the limit
+        """
+        key = item.key_for(*identifiers)
+
+        if await self.storage.incr(key, item.get_expiry(), amount=cost) <= item.amount:
+            return True
+        # Overshot the limit: roll back the slots we just acquired.
+        await cast(ConcurrencyLimitSupport, self.storage).decr(key, amount=cost)
+
+        return False
+
+    async def release(
+        self, item: RateLimitItem, *identifiers: str, cost: int = 1
+    ) -> None:
+        """
+        Release ``cost`` concurrency slots previously acquired with
+        :meth:`hit`. The underlying counter is floored at zero.
+
+        :param item: The rate limit item
+        :param identifiers: variable list of strings to uniquely identify this
+         instance of the limit
+        :param cost: The number of slots to release, default 1
+        """
+        await cast(ConcurrencyLimitSupport, self.storage).decr(
+            item.key_for(*identifiers), amount=cost
+        )
+
+    async def test(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
+        """
+        Check whether ``cost`` slots could be acquired without consuming them.
+
+        :param item: The rate limit item
+        :param identifiers: variable list of strings to uniquely identify this
+         instance of the limit
+        :param cost: The number of slots to test for, default 1
+
+        :return: True if there is room for ``cost`` more concurrent slots
+        """
+
+        return await self.storage.get(item.key_for(*identifiers)) + cost <= item.amount
+
+    async def get_window_stats(
+        self, item: RateLimitItem, *identifiers: str
+    ) -> WindowStats:
+        """
+        Query the safety reset time and remaining number of concurrency slots.
+
+        :param item: The rate limit item
+        :param identifiers: variable list of strings to uniquely identify this
+         instance of the limit
+        :return: (reset time, remaining)
+        """
+        key = item.key_for(*identifiers)
+        remaining = max(0, item.amount - await self.storage.get(key))
+        reset = await self.storage.get_expiry(key)
+
+        return WindowStats(reset, remaining)
+
+
 STRATEGIES = {
     "sliding-window-counter": SlidingWindowCounterRateLimiter,
     "fixed-window": FixedWindowRateLimiter,
     "moving-window": MovingWindowRateLimiter,
+    "concurrency-limit": ConcurrencyLimitRateLimiter,
 }

--- a/limits/storage/base.py
+++ b/limits/storage/base.py
@@ -222,6 +222,36 @@ class SlidingWindowCounterSupport(ABC):
         ...
 
 
+class ConcurrencyLimitSupport(ABC):
+    """
+    Abstract base class for storages that support
+    the :ref:`strategies:concurrency limit` strategy.
+    """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:  # type: ignore[explicit-any]
+        for method in {
+            "decr",
+        }:
+            setattr(
+                cls,
+                method,
+                _wrap_errors(getattr(cls, method)),
+            )
+        super().__init_subclass__(**kwargs)
+
+    @abstractmethod
+    def decr(self, key: str, amount: int = 1) -> int:
+        """
+        decrements the counter for a given rate limit key. The counter is
+        floored at zero so that a release can never take it below the number
+        of currently held slots.
+
+        :param key: the key to decrement
+        :param amount: the number to decrement by
+        """
+        raise NotImplementedError
+
+
 class TimestampedSlidingWindow:
     """Helper class for storage that support the sliding window counter, with timestamp based keys."""
 

--- a/limits/storage/memory.py
+++ b/limits/storage/memory.py
@@ -8,6 +8,7 @@ from math import floor
 
 import limits.typing
 from limits.storage.base import (
+    ConcurrencyLimitSupport,
     MovingWindowSupport,
     SlidingWindowCounterSupport,
     Storage,
@@ -22,7 +23,11 @@ class Entry:
 
 
 class MemoryStorage(
-    Storage, MovingWindowSupport, SlidingWindowCounterSupport, TimestampedSlidingWindow
+    Storage,
+    MovingWindowSupport,
+    SlidingWindowCounterSupport,
+    ConcurrencyLimitSupport,
+    TimestampedSlidingWindow,
 ):
     """
     rate limit storage using :class:`collections.Counter`

--- a/limits/strategies.py
+++ b/limits/strategies.py
@@ -10,7 +10,7 @@ from math import floor, inf
 
 from deprecated.sphinx import versionadded
 
-from limits.storage.base import SlidingWindowCounterSupport
+from limits.storage.base import ConcurrencyLimitSupport, SlidingWindowCounterSupport
 
 from .limits import RateLimitItem
 from .storage import MovingWindowSupport, Storage, StorageTypes
@@ -305,14 +305,97 @@ class SlidingWindowCounterRateLimiter(RateLimiter):
         )
 
 
+@versionadded(version="5.9")
+class ConcurrencyLimitRateLimiter(RateLimiter):
+    """
+    Reference: :ref:`strategies:concurrency limit`
+    """
+
+    def __init__(self, storage: StorageTypes):
+        if not hasattr(storage, "decr"):
+            raise NotImplementedError(
+                "ConcurrencyLimiting is not implemented for storage "
+                f"of type {storage.__class__}"
+            )
+        super().__init__(storage)
+
+    def hit(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
+        """
+        Acquire ``cost`` concurrency slots if doing so does not exceed the
+        limit. Slots are held until :meth:`release` is called (a safety expiry
+        of ``item.get_expiry()`` guards against slots leaked by callers that
+        never release).
+
+        :param item: The rate limit item
+        :param identifiers: variable list of strings to uniquely identify this
+         instance of the limit
+        :param cost: The number of slots to acquire, default 1
+
+        :return: True if the slots could be acquired without exceeding the limit
+        """
+        key = item.key_for(*identifiers)
+
+        if self.storage.incr(key, item.get_expiry(), amount=cost) <= item.amount:
+            return True
+        # Overshot the limit: roll back the slots we just acquired.
+        cast(ConcurrencyLimitSupport, self.storage).decr(key, amount=cost)
+
+        return False
+
+    def release(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> None:
+        """
+        Release ``cost`` concurrency slots previously acquired with
+        :meth:`hit`. The underlying counter is floored at zero.
+
+        :param item: The rate limit item
+        :param identifiers: variable list of strings to uniquely identify this
+         instance of the limit
+        :param cost: The number of slots to release, default 1
+        """
+        cast(ConcurrencyLimitSupport, self.storage).decr(
+            item.key_for(*identifiers), amount=cost
+        )
+
+    def test(self, item: RateLimitItem, *identifiers: str, cost: int = 1) -> bool:
+        """
+        Check whether ``cost`` slots could be acquired without consuming them.
+
+        :param item: The rate limit item
+        :param identifiers: variable list of strings to uniquely identify this
+         instance of the limit
+        :param cost: The number of slots to test for, default 1
+
+        :return: True if there is room for ``cost`` more concurrent slots
+        """
+
+        return self.storage.get(item.key_for(*identifiers)) + cost <= item.amount
+
+    def get_window_stats(self, item: RateLimitItem, *identifiers: str) -> WindowStats:
+        """
+        Query the safety reset time and remaining number of concurrency slots.
+
+        :param item: The rate limit item
+        :param identifiers: variable list of strings to uniquely identify this
+         instance of the limit
+        :return: (reset time, remaining)
+        """
+        key = item.key_for(*identifiers)
+        remaining = max(0, item.amount - self.storage.get(key))
+        reset = self.storage.get_expiry(key)
+
+        return WindowStats(reset, remaining)
+
+
 KnownStrategy = (
     type[SlidingWindowCounterRateLimiter]
     | type[FixedWindowRateLimiter]
     | type[MovingWindowRateLimiter]
+    | type[ConcurrencyLimitRateLimiter]
 )
 
 STRATEGIES: dict[str, KnownStrategy] = {
     "sliding-window-counter": SlidingWindowCounterRateLimiter,
     "fixed-window": FixedWindowRateLimiter,
     "moving-window": MovingWindowRateLimiter,
+    "concurrency-limit": ConcurrencyLimitRateLimiter,
 }

--- a/tests/aio/test_strategy.py
+++ b/tests/aio/test_strategy.py
@@ -6,6 +6,7 @@ from math import ceil
 import pytest
 
 from limits.aio.strategies import (
+    ConcurrencyLimitRateLimiter,
     FixedWindowRateLimiter,
     MovingWindowRateLimiter,
     SlidingWindowCounterRateLimiter,
@@ -19,6 +20,7 @@ from limits.storage import storage_from_string
 from limits.storage.base import TimestampedSlidingWindow
 from tests.utils import (
     async_all_storage,
+    async_concurrency_limiter_storage,
     async_fixed_start,
     async_moving_window_storage,
     async_sliding_window_counter_storage,
@@ -359,3 +361,76 @@ class TestAsyncSlidingWindow:
         assert await limiter.hit(limit)
         assert not await limiter.test(limit)
         assert not await limiter.hit(limit)
+
+
+@pytest.mark.asyncio
+@async_concurrency_limiter_storage
+class TestAsyncConcurrencyLimit:
+    async def test_concurrency_limit(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = ConcurrencyLimitRateLimiter(storage)
+        limit = RateLimitItemPerMinute(10)
+        assert all([await limiter.hit(limit) for _ in range(10)])
+        assert not await limiter.hit(limit)
+        assert (await limiter.get_window_stats(limit)).remaining == 0
+        # releasing a slot frees capacity for exactly one more concurrent hit
+        await limiter.release(limit)
+        assert (await limiter.get_window_stats(limit)).remaining == 1
+        assert await limiter.hit(limit)
+        assert not await limiter.hit(limit)
+
+    async def test_concurrency_limit_empty_stats(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = ConcurrencyLimitRateLimiter(storage)
+        limit = RateLimitItemPerMinute(10)
+        assert (await limiter.get_window_stats(limit)).remaining == 10
+
+    async def test_concurrency_limit_multiple_cost(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = ConcurrencyLimitRateLimiter(storage)
+        limit = RateLimitItemPerMinute(10)
+        assert not await limiter.hit(limit, "k1", cost=11)
+        assert await limiter.hit(limit, "k2", cost=5)
+        assert (await limiter.get_window_stats(limit, "k2")).remaining == 5
+        assert not await limiter.test(limit, "k2", cost=6)
+        assert not await limiter.hit(limit, "k2", cost=6)
+        # a rejected hit must not consume any slots
+        assert (await limiter.get_window_stats(limit, "k2")).remaining == 5
+        await limiter.release(limit, "k2", cost=5)
+        assert (await limiter.get_window_stats(limit, "k2")).remaining == 10
+
+    async def test_test_concurrency_limit(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = ConcurrencyLimitRateLimiter(storage)
+        limit = RateLimitItemPerMinute(2)
+        assert await limiter.test(limit)
+        assert await limiter.hit(limit)
+        assert await limiter.test(limit)
+        assert await limiter.hit(limit)
+        # limit reached: neither test nor hit may pass
+        assert not await limiter.test(limit)
+        assert not await limiter.hit(limit)
+        # test() must not consume slots, so a release always makes room again
+        await limiter.release(limit)
+        assert await limiter.test(limit)
+
+    async def test_concurrency_limit_release_floors_at_zero(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = ConcurrencyLimitRateLimiter(storage)
+        limit = RateLimitItemPerMinute(5)
+        assert await limiter.hit(limit)
+        # releasing more than is held can never take remaining above the limit
+        await limiter.release(limit, cost=10)
+        assert (await limiter.get_window_stats(limit)).remaining == 5
+        assert all([await limiter.hit(limit) for _ in range(5)])
+        assert not await limiter.hit(limit)
+
+    async def test_concurrency_limit_clear(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = ConcurrencyLimitRateLimiter(storage)
+        limit = RateLimitItemPerMinute(5)
+        assert all([await limiter.hit(limit) for _ in range(5)])
+        assert not await limiter.hit(limit)
+        await limiter.clear(limit)
+        assert (await limiter.get_window_stats(limit)).remaining == 5
+        assert await limiter.hit(limit)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -13,12 +13,14 @@ from limits.limits import (
 from limits.storage import storage_from_string
 from limits.storage.base import TimestampedSlidingWindow
 from limits.strategies import (
+    ConcurrencyLimitRateLimiter,
     FixedWindowRateLimiter,
     MovingWindowRateLimiter,
     SlidingWindowCounterRateLimiter,
 )
 from tests.utils import (
     all_storage,
+    concurrency_limiter_storage,
     fixed_start,
     moving_window_storage,
     sliding_window_counter_storage,
@@ -340,3 +342,75 @@ class TestMovingWindow:
         assert limiter.hit(limit)
         assert not limiter.test(limit)
         assert not limiter.hit(limit)
+
+
+@concurrency_limiter_storage
+class TestConcurrencyLimit:
+    def test_concurrency_limit(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = ConcurrencyLimitRateLimiter(storage)
+        limit = RateLimitItemPerMinute(10)
+        assert all(limiter.hit(limit) for _ in range(10))
+        assert not limiter.hit(limit)
+        assert limiter.get_window_stats(limit).remaining == 0
+        # releasing a slot frees capacity for exactly one more concurrent hit
+        limiter.release(limit)
+        assert limiter.get_window_stats(limit).remaining == 1
+        assert limiter.hit(limit)
+        assert not limiter.hit(limit)
+
+    def test_concurrency_limit_empty_stats(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = ConcurrencyLimitRateLimiter(storage)
+        limit = RateLimitItemPerMinute(10)
+        assert limiter.get_window_stats(limit).remaining == 10
+
+    def test_concurrency_limit_multiple_cost(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = ConcurrencyLimitRateLimiter(storage)
+        limit = RateLimitItemPerMinute(10)
+        assert not limiter.hit(limit, "k1", cost=11)
+        assert limiter.hit(limit, "k2", cost=5)
+        assert limiter.get_window_stats(limit, "k2").remaining == 5
+        assert not limiter.test(limit, "k2", cost=6)
+        assert not limiter.hit(limit, "k2", cost=6)
+        # a rejected hit must not consume any slots
+        assert limiter.get_window_stats(limit, "k2").remaining == 5
+        limiter.release(limit, "k2", cost=5)
+        assert limiter.get_window_stats(limit, "k2").remaining == 10
+
+    def test_test_concurrency_limit(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = ConcurrencyLimitRateLimiter(storage)
+        limit = RateLimitItemPerMinute(2)
+        assert limiter.test(limit)
+        assert limiter.hit(limit)
+        assert limiter.test(limit)
+        assert limiter.hit(limit)
+        # limit reached: neither test nor hit may pass
+        assert not limiter.test(limit)
+        assert not limiter.hit(limit)
+        # test() must not consume slots, so a release always makes room again
+        limiter.release(limit)
+        assert limiter.test(limit)
+
+    def test_concurrency_limit_release_floors_at_zero(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = ConcurrencyLimitRateLimiter(storage)
+        limit = RateLimitItemPerMinute(5)
+        assert limiter.hit(limit)
+        # releasing more than is held can never take remaining above the limit
+        limiter.release(limit, cost=10)
+        assert limiter.get_window_stats(limit).remaining == 5
+        assert all(limiter.hit(limit) for _ in range(5))
+        assert not limiter.hit(limit)
+
+    def test_concurrency_limit_clear(self, uri, args, fixture):
+        storage = storage_from_string(uri, **args)
+        limiter = ConcurrencyLimitRateLimiter(storage)
+        limit = RateLimitItemPerMinute(5)
+        assert all(limiter.hit(limit) for _ in range(5))
+        assert not limiter.hit(limit)
+        limiter.clear(limit)
+        assert limiter.get_window_stats(limit).remaining == 5
+        assert limiter.hit(limit)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -287,6 +287,12 @@ sliding_window_counter_storage = pytest.mark.parametrize(
     "uri, args, fixture", ALL_STORAGES.values()
 )
 
+# Storages that support the concurrency limit strategy (i.e. expose ``decr``).
+concurrency_limiter_storage = pytest.mark.parametrize(
+    "uri, args, fixture",
+    [storage for name, storage in ALL_STORAGES.items() if name in {"memory"}],
+)
+
 async_all_storage = pytest.mark.parametrize(
     "uri, args, fixture", ALL_STORAGES_ASYNC.values()
 )
@@ -302,4 +308,10 @@ async_moving_window_storage = pytest.mark.parametrize(
 
 async_sliding_window_counter_storage = pytest.mark.parametrize(
     "uri, args, fixture", ALL_STORAGES_ASYNC.values()
+)
+
+# Storages that support the concurrency limit strategy (i.e. expose ``decr``).
+async_concurrency_limiter_storage = pytest.mark.parametrize(
+    "uri, args, fixture",
+    [storage for name, storage in ALL_STORAGES_ASYNC.items() if name in {"memory"}],
 )


### PR DESCRIPTION
This revives #233, which was approved by reviewers but closed for inactivity after a request to add tests. The original branch was ~2 years (307 commits) behind `master`, so this reintroduces the strategy on top of the current storage API and addresses the test request.

## What this adds

- **`ConcurrencyLimitRateLimiter`** (sync `limits.strategies` + async `limits.aio.strategies`), registered as the `concurrency-limit` strategy. Unlike the window-based strategies it bounds *in-flight concurrency*: `hit()` acquires slots and `release()` hands them back. A safety expiry (derived from the limit period) reclaims slots leaked by callers that never release.
- **`ConcurrencyLimitSupport`** capability mixin (sync + async) exposing `decr`, mirroring the existing `MovingWindowSupport` / `SlidingWindowCounterSupport` pattern. The in-memory storage (which already implements `decr`) opts in; the limiter raises `NotImplementedError` for storages that don't support it.
- **Tests** (the change requested on #233): sync + async suites covering acquire/release, multi-cost, rejection-without-consumption, release flooring at zero, and clear.
- **Docs**: README, strategies guide, and API reference.

## Notes

- `hit()` uses acquire-then-rollback (`incr`, then `decr` on overflow) so the counter stays accurate under contention and rejected hits never consume a slot — an improvement over the original get-then-incr which had a race.
- `decr` currently only exists on the in-memory storage, so the strategy is wired for in-memory here; extending `decr` to the redis / memcached / mongodb backends to broaden support can follow.

Supersedes #233.
