### PR TITLE
Fix Read the Docs build: use ubuntu-24.04 image

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.13"
   commands:


### PR DESCRIPTION
## Problem

Read the Docs builds have been failing on `master` and on every open PR since ~2026-06-22, before any docs are built:

> Config validation error in `build.os`.
> Expected one of (ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, ubuntu-lts-latest), got type `str` (`ubuntu-20.04`).

Read the Docs retired the `ubuntu-20.04` build image, but `.readthedocs.yml` still pins `build.os: ubuntu-20.04`, so the build fails at config validation (~1s). The last successful RTD build was on 2026-06-03 (commit 19d4574), before the image was removed.

## Fix

Bump `build.os` to a currently supported image (`ubuntu-24.04`). Nothing else changes — the `python: "3.13"` toolchain and the build commands are identical to the last green build.

Verified: reproduced the RTD build locally with this change and sphinx builds all pages successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)